### PR TITLE
Elfman2/do178

### DIFF
--- a/templates/DO-178C/doc/software/requirements/DD.rst
+++ b/templates/DO-178C/doc/software/requirements/DD.rst
@@ -1,4 +1,9 @@
 Detailed design
 $$$$$$$$$$$$$$$
 
+.. _imu:
+
+IMU detailed design
+~~~~~~~~~~~~~~~~~~~
+
 .. doxygenfile:: imu.h

--- a/templates/DO-178C/doc/software/requirements/DD.rst
+++ b/templates/DO-178C/doc/software/requirements/DD.rst
@@ -1,0 +1,4 @@
+Detailed design
+$$$$$$$$$$$$$$$
+
+.. doxygenfile:: imu.h

--- a/templates/DO-178C/doc/software/requirements/SDD.sdoc
+++ b/templates/DO-178C/doc/software/requirements/SDD.sdoc
@@ -60,6 +60,10 @@ The software component **imu** shall ....
 [SECTION]
 TITLE: Detailed design
 
+[FREETEXT]
+- ``[imu]`` :ref:`imu`
+[/FREETEXT]
+
 [/SECTION]
 
 [/SECTION]

--- a/templates/DO-178C/doc/software/requirements/SDD.sdoc
+++ b/templates/DO-178C/doc/software/requirements/SDD.sdoc
@@ -39,7 +39,9 @@ The IMU_AZ data is read from the data field in the Arinc word defined by:
 .. image:: ../../../_assets/A429.*
 <<<
 COMMENT: >>>
-https://fr.wikipedia.org/wiki/ARINC_429
+Refer to `Arinc 429 definition`_
+
+.. _`Arinc 429 definition`: https://fr.wikipedia.org/wiki/ARINC_429
 <<<
 
 [SECTION]
@@ -61,7 +63,9 @@ The software component **imu** shall ....
 TITLE: Detailed design
 
 [FREETEXT]
-- ``[imu]`` :ref:`imu`
+See `IMU detailed design`_
+
+.. _IMU detailed design: https://strictdoc-templates.readthedocs.io/en/latest/doc/software/requirements/DD.html#imu-detailed-design
 [/FREETEXT]
 
 [/SECTION]

--- a/templates/DO-178C/doc/software/requirements/SDD.sdoc
+++ b/templates/DO-178C/doc/software/requirements/SDD.sdoc
@@ -60,11 +60,6 @@ The software component **imu** shall ....
 [SECTION]
 TITLE: Detailed design
 
-[FREETEXT]
-. doxygenfile:: imu.h
-   :project: DO-178C
-[/FREETEXT]
-
 [/SECTION]
 
 [/SECTION]

--- a/templates/DO-178C/doc/software/verification/SVCP.sdoc
+++ b/templates/DO-178C/doc/software/verification/SVCP.sdoc
@@ -11,6 +11,13 @@ Details the scope and depth of review and analysis procedures
 [/SECTION]
 
 [SECTION]
+TITLE: High Level Tests (HLT)
+
+[FREETEXT]
+Description of test case and procedures linked to high level requirements, typically referred a black box tests. The software under test is typically the integrated executable. The test shall exercise software external interfaces.
+[/FREETEXT]
+
+[SECTION]
 TITLE: Test cases
 
 [FREETEXT]
@@ -25,5 +32,36 @@ TITLE: Test procedures
 [FREETEXT]
 Test envionment to run step by step instructions to run test cases. Describes how test results are evaluated.
 [/FREETEXT]
+
+[/SECTION]
+
+[/SECTION]
+
+[SECTION]
+TITLE: Low Level Tests (LLT)
+
+[FREETEXT]
+Description of test case and procedures linked to low level requirements, typically referred as unit tests.
+The software under test is a software unit where dependencies are stubbed.
+The test shall exercise the software unit specified in detailed design document.
+[/FREETEXT]
+
+[SECTION]
+TITLE: Test cases
+
+[FREETEXT]
+Details test cases environment, input, expected results, pass/fail criteria.
+[/FREETEXT]
+
+[/SECTION]
+
+[SECTION]
+TITLE: Test procedures
+
+[FREETEXT]
+Test envionment to run step by step instructions to run test cases. Describes how test results are evaluated.
+[/FREETEXT]
+
+[/SECTION]
 
 [/SECTION]

--- a/templates/DO-178C/index.rst
+++ b/templates/DO-178C/index.rst
@@ -34,6 +34,7 @@ Welcome to DO178C template documentation!
    ./rst/system/SR.rst
    ./rst/software/requirements/SRD.rst
    ./rst/software/requirements/SDD.rst
+   ./doc/software/requirements/DD.rst
 
 .. toctree::
    :numbered:


### PR DESCRIPTION
The workaround to get both sdoc and doxygen:
Specify doxygen/breathe directive in a separate .rst file out of sdoc.
This .rst will be referenced by index.rst for sphinx build.
In .sdoc, to reference doxygen page, use of an external link to the .rst URL
