### PR TITLE
templates: add IEC 61508 safety lifecycle document templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The following standards are available:
 
 - ECSS-E-ST-40-C (space industry, software)
 - DO-178C (aviation industry, software)
+- IEC 61508 (functional safety, E/E/PE safety-related systems)
 - Template of EU Regulation 2024/2847 (EU Cyber Resilience Act)
 - ETSI EN 303 645 v2.1.1 (IOT cyber security)
 - ETSI EN 304 626 v0.11 (OS cyber security)

--- a/templates/iec-61508-3/01_overall_safety_plan.sdoc
+++ b/templates/iec-61508-3/01_overall_safety_plan.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Overall Safety Plan
+TITLE: Overall safety plan
 OPTIONS:
   MARKUP: Text
 
@@ -21,7 +21,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -39,7 +39,7 @@ Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Scope and Purpose
+TITLE: Scope and purpose
 
 [TEXT]
 STATEMENT: >>>
@@ -95,7 +95,7 @@ shall be assigned.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Safety Lifecycle Definition
+TITLE: Safety lifecycle definition
 
 [TEXT]
 STATEMENT: >>>
@@ -148,7 +148,7 @@ VERIFICATION_METHOD: Inspection
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Responsibilities and Competence
+TITLE: Responsibilities and competence
 
 [REQUIREMENT]
 UID: OSP-020
@@ -192,7 +192,7 @@ independent body) is Highly Recommended.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Functional Safety Assessment Planning
+TITLE: Functional safety assessment planning
 
 [TEXT]
 STATEMENT: >>>
@@ -241,7 +241,7 @@ VERIFICATION_METHOD: Inspection
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Configuration Management and Documentation Control
+TITLE: Configuration management and documentation control
 
 [REQUIREMENT]
 UID: OSP-040

--- a/templates/iec-61508-3/01_overall_safety_plan.sdoc
+++ b/templates/iec-61508-3/01_overall_safety_plan.sdoc
@@ -1,0 +1,295 @@
+[DOCUMENT]
+TITLE: Overall Safety Plan
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document is the Overall Safety Plan (OSP) for the E/E/PE safety-related system
+identified below. It is prepared in accordance with IEC 61508-1:2010, Clause 6.2
+(Overall safety management) and references the applicable sub-plans for each safety
+lifecycle phase.
+
+Instructions for use:
+- Replace all placeholder text in angle brackets <...> with project-specific information.
+- Assign UIDs following the project numbering convention, e.g. OSP-001, OSP-002, ...
+- Set STATUS of each requirement to "Draft" during development, "Active" once approved.
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+System:          <E/E/PE safety-related system name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Scope and Purpose
+
+[TEXT]
+STATEMENT: >>>
+IEC 61508-1:2010, Clause 6.2.1 requires the Overall Safety Plan to define the
+management and technical activities required to achieve functional safety throughout
+the safety lifecycle. This document covers:
+
+- Definition of the overall safety lifecycle and its phases (IEC 61508-1 Figure 2).
+- Identification of responsible persons and organisations for each phase.
+- Planning of verification and validation activities.
+- Planning of functional safety assessment activities.
+- Configuration management and documentation control strategy.
+<<<
+
+[REQUIREMENT]
+UID: OSP-001
+STATUS: Draft
+TITLE: Overall safety lifecycle adoption
+STATEMENT: >>>
+The project shall implement the overall safety lifecycle as defined in
+IEC 61508-1:2010, Figure 2, covering all phases from concept through
+to decommissioning.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: >>>
+IEC 61508-1:2010, Clause 6.2.1: the overall safety lifecycle provides the
+framework for all functional safety activities.
+<<<
+
+[REQUIREMENT]
+UID: OSP-002
+STATUS: Draft
+TITLE: Functional safety management responsibility
+STATEMENT: >>>
+A competent person or organisation shall be assigned responsibility for
+overall functional safety management for the project, with defined authority
+to ensure compliance with this plan.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: >>>
+IEC 61508-1:2010, Clause 6.2.1.3: overall safety management responsibility
+shall be assigned.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Safety Lifecycle Definition
+
+[TEXT]
+STATEMENT: >>>
+Define the phases of the safety lifecycle applicable to this project, mapping them
+to IEC 61508-1:2010 Figure 2. Identify which phases are within scope and which are
+excluded (with justification).
+<<<
+
+[REQUIREMENT]
+UID: OSP-010
+STATUS: Draft
+TITLE: Safety lifecycle phase definition
+STATEMENT: >>>
+The Overall Safety Plan shall identify each safety lifecycle phase applicable
+to this project, with entry and exit criteria, deliverables, and responsible
+organisations for each phase.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+COMMENT: >>>
+Phases to address: Concept, Overall Scope Definition, Hazard and Risk Analysis,
+Overall Safety Requirements, Safety Requirements Allocation, Overall Planning,
+Realisation, Overall Installation, Overall Safety Validation,
+Overall Operation and Maintenance, Decommissioning.
+<<<
+
+[REQUIREMENT]
+UID: OSP-011
+STATUS: Draft
+TITLE: Sub-plans reference
+STATEMENT: >>>
+The Overall Safety Plan shall reference the following sub-plans applicable
+to the realisation phase:
+- Software Safety Plan (IEC 61508-3, Clause 6.2)
+- Hardware Safety Plan (IEC 61508-2, Clause 6.2)
+- Functional Safety Assessment Plan (IEC 61508-1, Clause 8)
+- Verification Plan
+- Validation Plan
+- Configuration Management Plan
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Responsibilities and Competence
+
+[REQUIREMENT]
+UID: OSP-020
+STATUS: Draft
+TITLE: Competence requirements
+STATEMENT: >>>
+Persons assigned to functional safety activities shall have the necessary
+competence, as demonstrated by education, training, and/or experience,
+appropriate to the SIL of the safety function(s) for which they are
+responsible.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: >>>
+IEC 61508-1:2010, Clause 6.2.1.4 and Annex C.
+<<<
+
+[REQUIREMENT]
+UID: OSP-021
+STATUS: Draft
+TITLE: Independence of verification and assessment
+STATEMENT: >>>
+Functional safety verification activities and the Functional Safety Assessment
+shall be carried out by persons or organisations that are independent from
+the design activities, at the level of independence required by the target SIL.
+<<<
+SIL_1: R
+SIL_2: R
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: >>>
+IEC 61508-1:2010, Clause 8 and Table 4: independence requirements are
+graduated by SIL. For SIL 3/4, full independence (different organisation or
+independent body) is Highly Recommended.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Functional Safety Assessment Planning
+
+[TEXT]
+STATEMENT: >>>
+Define the strategy for conducting the Functional Safety Assessment (FSA) in
+accordance with IEC 61508-1:2010, Clause 8. Identify the assessment phases,
+independence level, and the assessor or assessment body.
+<<<
+
+[REQUIREMENT]
+UID: OSP-030
+STATUS: Draft
+TITLE: FSA phases
+STATEMENT: >>>
+A Functional Safety Assessment shall be planned and performed at the following
+lifecycle points:
+a) After the Hazard and Risk Analysis is complete.
+b) After the Overall Safety Requirements Specification is complete.
+c) After design and realisation is complete and prior to operation.
+d) After overall safety validation is complete.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: >>>
+IEC 61508-1:2010, Clause 8.2.2: the FSA shall consider all relevant safety
+lifecycle phases.
+<<<
+
+[REQUIREMENT]
+UID: OSP-031
+STATUS: Draft
+TITLE: FSA independence level
+STATEMENT: >>>
+The independence level of the Functional Safety Assessor shall meet or exceed
+the level defined in IEC 61508-1:2010, Table 4 for the target SIL of the
+highest SIL safety function in scope.
+<<<
+SIL_1: R
+SIL_2: R
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Configuration Management and Documentation Control
+
+[REQUIREMENT]
+UID: OSP-040
+STATUS: Draft
+TITLE: Configuration management plan
+STATEMENT: >>>
+A Configuration Management Plan shall be established and maintained, covering
+identification, version control, change control, and status accounting for all
+safety lifecycle deliverables.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: >>>
+IEC 61508-1:2010, Clause 6.2.1.5.
+<<<
+
+[REQUIREMENT]
+UID: OSP-041
+STATUS: Draft
+TITLE: Documentation retention
+STATEMENT: >>>
+All safety lifecycle documentation shall be retained for a period consistent
+with the operational life of the system and applicable regulatory requirements,
+and shall remain retrievable and traceable.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-1:2010, Functional safety of E/E/PE safety-related systems –
+    Part 1: General requirements.
+[2] IEC 61508-2:2010, Functional safety of E/E/PE safety-related systems –
+    Part 2: Requirements for E/E/PE safety-related systems.
+[3] IEC 61508-3:2010, Functional safety of E/E/PE safety-related systems –
+    Part 3: Software requirements.
+[4] <Project-specific references>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/02_hazard_risk_analysis.sdoc
+++ b/templates/iec-61508-3/02_hazard_risk_analysis.sdoc
@@ -1,0 +1,186 @@
+[DOCUMENT]
+TITLE: Hazard and Risk Analysis
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document records the Hazard and Risk Analysis (HARA) for the E/E/PE safety-related
+system identified below. It is prepared in accordance with IEC 61508-1:2010, Clause 7.4
+and Annex D (Risk Graph method).
+
+The Risk Graph method (IEC 61508-1:2010, Annex D) is used as the primary method for
+SIL determination. If an alternative method (e.g. LOPA, numerical risk target) is used
+for a specific hazard, this shall be documented in the RISK_METHOD_ALT field.
+
+Risk Graph parameters:
+  C – Consequence of the hazardous event:
+      C1 = Slight injury,  C2 = Serious injury (one person),
+      C3 = Several people killed,  C4 = Many people killed.
+  F – Frequency / exposure:
+      F1 = Rare to less often,  F2 = Frequent to continuous.
+  P – Possibility of avoiding the hazard:
+      P1 = Possible,  P2 = Almost impossible.
+  W – Probability of unwanted occurrence (without protective system):
+      W1 = Very slight,  W2 = Slight,  W3 = Relatively high.
+
+Instructions for use:
+- Assign a unique UID to each HAZARD node, e.g. HAZ-001, HAZ-002, ...
+- Fill all Risk Graph parameters for each hazard.
+- The SIL_REQUIRED value shall be derived from the Risk Graph (Annex D, Figure D.1).
+- If SIL_REQUIRED is No-SIL-Required, document the justification in COMMENT.
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+System:          <E/E/PE safety-related system name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: System and EUC Description
+
+[TEXT]
+STATEMENT: >>>
+Describe the Equipment Under Control (EUC) and the system under analysis.
+Include:
+- EUC boundary and intended use
+- Operational modes
+- Environmental conditions
+- Assumed operator competence
+- Interfaces to other systems
+
+EUC Description: <Describe the EUC>
+System Boundary: <Define the system boundary for this analysis>
+Operational Modes: <Normal, Test, Maintenance, Emergency>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Hazard Identification Method
+
+[TEXT]
+STATEMENT: >>>
+Describe the hazard identification method(s) used, e.g.:
+- Structured HAZOP
+- What-If analysis
+- Failure Mode and Effects Analysis (FMEA)
+- Checklist-based review
+
+Method used: <Describe method(s)>
+Team composition: <List participants and roles>
+Session dates: <YYYY-MM-DD>
+Reference documents: <List applicable drawings, P&IDs, functional specs>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Hazard Register
+
+[TEXT]
+STATEMENT: >>>
+Each hazard is described using a HAZARD node. The SIL_REQUIRED field records
+the SIL derived from the Risk Graph (IEC 61508-1:2010, Annex D, Figure D.1)
+or from the alternative method documented in RISK_METHOD_ALT.
+<<<
+
+[HAZARD]
+UID: HAZ-001
+STATUS: Draft
+TITLE: <Short hazard name>
+HAZARD_DESCRIPTION: >>>
+<Describe the hazardous event: what can go wrong, under what conditions.>
+<<<
+CAUSE: >>>
+<Root cause(s) of the hazardous event.>
+<<<
+CONSEQUENCE: >>>
+<Consequence to persons, environment or property if the hazard is not controlled.>
+<<<
+RISK_GRAPH_C: C1
+RISK_GRAPH_F: F1
+RISK_GRAPH_P: P1
+RISK_GRAPH_W: W1
+SIL_REQUIRED: --
+RISK_METHOD_ALT: >>>
+<If an alternative method is used, describe it here and reference supporting
+calculations. Leave blank if Risk Graph is used.>
+<<<
+MITIGATION: >>>
+<Describe the safety function(s) or other risk reduction measure(s) that address
+this hazard. Reference the corresponding SRS requirement UID(s).>
+<<<
+COMMENT: >>>
+<Additional notes, assumptions, or open points.>
+<<<
+
+[HAZARD]
+UID: HAZ-002
+STATUS: Draft
+TITLE: <Short hazard name>
+HAZARD_DESCRIPTION: >>>
+<Describe the hazardous event.>
+<<<
+CAUSE: >>>
+<Root cause(s).>
+<<<
+CONSEQUENCE: >>>
+<Consequence.>
+<<<
+RISK_GRAPH_C: C1
+RISK_GRAPH_F: F1
+RISK_GRAPH_P: P1
+RISK_GRAPH_W: W1
+SIL_REQUIRED: --
+MITIGATION: >>>
+<Safety function(s) addressing this hazard.>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Summary of SIL Requirements
+
+[TEXT]
+STATEMENT: >>>
+Summarise the SIL requirements allocated to each safety function identified
+from the hazard register above. This summary feeds directly into the Overall
+Safety Requirements Specification (SRS).
+
+Safety Function | Hazards Addressed | SIL Required
+<SF-1>          | HAZ-001           | <SIL x>
+<SF-2>          | HAZ-002           | <SIL x>
+
+The highest SIL requirement across all safety functions is: <SIL x>.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-1:2010, Annex D – Example of a risk graph for the determination
+    of the safety integrity level.
+[2] <Project-specific references, drawings, P&IDs>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/02_hazard_risk_analysis.sdoc
+++ b/templates/iec-61508-3/02_hazard_risk_analysis.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Hazard and Risk Analysis
+TITLE: Hazard and risk analysis
 OPTIONS:
   MARKUP: Text
 
@@ -36,7 +36,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -53,7 +53,7 @@ Classification:  <Confidential / Restricted / Public>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: System and EUC Description
+TITLE: System and EUC description
 
 [TEXT]
 STATEMENT: >>>
@@ -73,7 +73,7 @@ Operational Modes: <Normal, Test, Maintenance, Emergency>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Hazard Identification Method
+TITLE: Hazard identification method
 
 [TEXT]
 STATEMENT: >>>
@@ -92,7 +92,7 @@ Reference documents: <List applicable drawings, P&IDs, functional specs>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Hazard Register
+TITLE: Hazard register
 
 [TEXT]
 STATEMENT: >>>
@@ -156,7 +156,7 @@ MITIGATION: >>>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Summary of SIL Requirements
+TITLE: Summary of SIL requirements
 
 [TEXT]
 STATEMENT: >>>

--- a/templates/iec-61508-3/03_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/03_safety_requirements_spec.sdoc
@@ -81,8 +81,8 @@ For each safety function specify:
 UID: SRS-010
 STATUS: Draft
 TITLE: <Safety Function 1 name>
-STATEMENT: >>>
 SAFETY_FUNCTION: SF-1
+STATEMENT: >>>
 The <system name> shall perform <describe the safety function: action> upon
 detection of <describe the initiating condition / process demand> within
 <response time> milliseconds, bringing the EUC to the safe state defined as
@@ -110,8 +110,8 @@ RELATIONS:
 UID: SRS-011
 STATUS: Draft
 TITLE: <Safety Function 2 name>
-STATEMENT: >>>
 SAFETY_FUNCTION: SF-2
+STATEMENT: >>>
 The <system name> shall <describe safety function 2>.
 
 Required SIL: <SIL x>

--- a/templates/iec-61508-3/03_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/03_safety_requirements_spec.sdoc
@@ -1,0 +1,272 @@
+[DOCUMENT]
+TITLE: Safety Requirements Specification
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document is the Overall Safety Requirements Specification (SRS) for the
+E/E/PE safety-related system identified below. It is prepared in accordance with
+IEC 61508-1:2010, Clause 7.6 (Overall safety requirements) and specifies the
+safety functions and safety integrity requirements to be allocated to the E/E/PE
+safety-related system.
+
+Instructions for use:
+- Each safety function shall have a corresponding REQUIREMENT node with SIL_REQUIRED.
+- UIDs follow convention: SRS-xxx.
+- Traceability back to the HARA is established via RELATIONS (Parent: HAZ-xxx).
+- The SIL_1 through SIL_4 fields indicate the applicability classification
+  (HR/R/NR/--) of this requirement type at each SIL level per IEC 61508-1.
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+System:          <E/E/PE safety-related system name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+HARA Reference:  <Document ID of Hazard and Risk Analysis>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: System Description and Scope
+
+[TEXT]
+STATEMENT: >>>
+Provide a description of the E/E/PE safety-related system, including:
+- System boundary (what is included and excluded)
+- Relationship to the EUC and EUC control system
+- Operational modes (Normal, Test, Maintenance, Emergency)
+- Environmental conditions (temperature, EMC, humidity, etc.)
+- Assumed operator qualifications
+- Interfaces to other systems (hardware and software)
+
+System description: <Describe the system>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Safety Functions
+
+[TEXT]
+STATEMENT: >>>
+This section specifies the safety functions to be performed by the E/E/PE
+safety-related system in accordance with IEC 61508-1:2010, Clause 7.6.2.
+Each safety function shall be traceable to one or more hazards in the HARA.
+
+For each safety function specify:
+- The hazardous event it addresses (reference to HARA)
+- The process demand / initiating condition
+- The required safe state
+- The required response time
+- The Safe Failure Fraction (SFF) target (informative at this stage)
+- The Target Failure Measure (PFH or PFD)
+<<<
+
+[REQUIREMENT]
+UID: SRS-010
+STATUS: Draft
+TITLE: <Safety Function 1 name>
+STATEMENT: >>>
+SAFETY_FUNCTION: SF-1
+The <system name> shall perform <describe the safety function: action> upon
+detection of <describe the initiating condition / process demand> within
+<response time> milliseconds, bringing the EUC to the safe state defined as
+<describe the safe state>.
+
+Required SIL: <SIL x>
+Target failure measure: PFH < <value> h⁻¹ (continuous mode) /
+                         PFD_avg < <value> (demand mode)
+Proof test interval: <value> hours (if applicable)
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis, Testing
+RATIONALE: >>>
+Derived from HARA, hazard HAZ-001. SIL requirement per IEC 61508-1:2010,
+Annex D Risk Graph.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: HAZ-001
+
+[REQUIREMENT]
+UID: SRS-011
+STATUS: Draft
+TITLE: <Safety Function 2 name>
+STATEMENT: >>>
+SAFETY_FUNCTION: SF-2
+The <system name> shall <describe safety function 2>.
+
+Required SIL: <SIL x>
+Target failure measure: PFH < <value> h⁻¹
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis, Testing
+RELATIONS:
+- TYPE: Parent
+  VALUE: HAZ-002
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Safety Integrity Requirements
+
+[[SECTION]]
+TITLE: Hardware Safety Integrity
+
+[REQUIREMENT]
+UID: SRS-020
+STATUS: Draft
+TITLE: Hardware SIL allocation
+STATEMENT: >>>
+The hardware of the E/E/PE safety-related system shall meet the hardware
+safety integrity requirements for <SIL x> as defined in
+IEC 61508-2:2010, Clause 7.4, including:
+- Safe Failure Fraction (SFF) target per Table 2 or Table 3.
+- Hardware Fault Tolerance (HFT) as required by the target SIL
+  and subsystem type (Type A or Type B).
+- Diagnostic coverage (DC) target.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis
+
+[REQUIREMENT]
+UID: SRS-021
+STATUS: Draft
+TITLE: Common Cause Failure avoidance
+STATEMENT: >>>
+The design shall include measures to avoid or control Common Cause Failures
+(CCF) in redundant hardware architectures, consistent with the requirements
+of IEC 61508-2:2010, Annex D.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis, Inspection
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Safety Integrity
+
+[REQUIREMENT]
+UID: SRS-030
+STATUS: Draft
+TITLE: Software SIL allocation
+STATEMENT: >>>
+The software of the E/E/PE safety-related system shall be designed, implemented,
+verified and validated to achieve software safety integrity consistent with
+<SIL x> as defined in IEC 61508-3:2010. The Software Safety Requirements
+Specification shall be derived from this SRS.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[REQUIREMENT]
+UID: SRS-031
+STATUS: Draft
+TITLE: Software architecture independence
+STATEMENT: >>>
+Where redundant software channels are used to achieve the required SIL, the
+software of each channel shall be designed and implemented independently to
+avoid systematic common cause failures, consistent with
+IEC 61508-3:2010, Clause 7.4.7.
+<<<
+SIL_1: NR
+SIL_2: R
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Non-Safety Functional Requirements and Constraints
+
+[TEXT]
+STATEMENT: >>>
+Specify constraints on the system that are not safety functions themselves but
+are necessary to ensure the safety functions can be realised. Examples:
+- Response time constraints
+- Availability / diagnostic test interval requirements
+- Fail-safe / fail-secure behaviour
+- Environmental ratings
+- Power supply constraints
+<<<
+
+[REQUIREMENT]
+UID: SRS-040
+STATUS: Draft
+TITLE: Fail-safe state definition
+STATEMENT: >>>
+The safe state(s) of the system shall be defined and shall be achievable
+in all foreseeable failure modes of the safety-related system.
+The safe state for each safety function is:
+<SF-1>: <define safe state>
+<SF-2>: <define safe state>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis, Testing
+
+[REQUIREMENT]
+UID: SRS-041
+STATUS: Draft
+TITLE: Diagnostic test interval
+STATEMENT: >>>
+The on-line diagnostic test interval for the safety-related system shall not
+exceed <value> hours, to maintain the assumed diagnostic coverage and achieve
+the target PFH / PFD.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis, Testing
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-1:2010, Clause 7.6 – Overall safety requirements.
+[2] IEC 61508-2:2010, Clause 7.4 – Hardware safety integrity.
+[3] IEC 61508-3:2010 – Software requirements.
+[4] <Document ID> – Hazard and Risk Analysis.
+[5] <Project-specific references>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/03_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/03_safety_requirements_spec.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Safety Requirements Specification
+TITLE: Safety requirements specification
 OPTIONS:
   MARKUP: Text
 
@@ -24,7 +24,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -42,7 +42,7 @@ HARA Reference:  <Document ID of Hazard and Risk Analysis>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: System Description and Scope
+TITLE: System description and scope
 
 [TEXT]
 STATEMENT: >>>
@@ -60,7 +60,7 @@ System description: <Describe the system>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Safety Functions
+TITLE: Safety functions
 
 [TEXT]
 STATEMENT: >>>
@@ -129,10 +129,10 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Safety Integrity Requirements
+TITLE: Safety integrity requirements
 
 [[SECTION]]
-TITLE: Hardware Safety Integrity
+TITLE: Hardware safety integrity
 
 [REQUIREMENT]
 UID: SRS-020
@@ -171,7 +171,7 @@ VERIFICATION_METHOD: Analysis, Inspection
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Safety Integrity
+TITLE: Software safety integrity
 
 [REQUIREMENT]
 UID: SRS-030
@@ -210,7 +210,7 @@ VERIFICATION_METHOD: Inspection
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Non-Safety Functional Requirements and Constraints
+TITLE: Non-safety functional requirements and constraints
 
 [TEXT]
 STATEMENT: >>>

--- a/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
@@ -79,8 +79,8 @@ Each requirement shall be unambiguous, verifiable, complete, and consistent.
 UID: SSRS-010
 STATUS: Draft
 TITLE: <Software safety function 1>
-STATEMENT: >>>
 SAFETY_FUNCTION: SF-1
+STATEMENT: >>>
 The software shall <describe the software behaviour required to realise
 the safety function, including: inputs monitored, logic applied, outputs
 commanded, timing constraints>.
@@ -106,8 +106,8 @@ RELATIONS:
 UID: SSRS-011
 STATUS: Draft
 TITLE: <Software safety function 2>
-STATEMENT: >>>
 SAFETY_FUNCTION: SF-2
+STATEMENT: >>>
 The software shall <describe the software behaviour for safety function 2>.
 <<<
 SIL_1: HR

--- a/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
@@ -1,0 +1,415 @@
+[DOCUMENT]
+TITLE: Software Safety Requirements Specification
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document is the Software Safety Requirements Specification (SSRS) for the
+software element of the E/E/PE safety-related system identified below. It is
+prepared in accordance with IEC 61508-3:2010, Clause 7.2.
+
+The SSRS defines the software safety requirements derived from the Overall Safety
+Requirements Specification (SRS). It is the primary input to the Software Design
+Specification (SDS) and the Software Test Specification (STS).
+
+SIL_1 through SIL_4 fields classify each requirement as:
+  HR = Highly Recommended (IEC 61508-3 Tables A.x)
+  R  = Recommended
+  NR = Not Recommended
+  -- = Not applicable at this SIL level
+
+Instructions for use:
+- UIDs follow convention: SSRS-xxx.
+- Traceability to SRS requirements is established via RELATIONS (Parent: SRS-xxx).
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+System:          <E/E/PE safety-related system name>
+Software Item:   <Software item / component name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
+SRS Reference:   <Document ID of Safety Requirements Specification>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Overview
+
+[TEXT]
+STATEMENT: >>>
+Describe the software item in the context of the overall safety-related system:
+- Purpose and role of the software in the safety function(s)
+- Software classification per IEC 61508-3:2010, Clause 7.1 (embedded / non-embedded)
+- Target hardware platform and operating environment
+- Programming language(s)
+- Run-time environment / RTOS (if applicable)
+- Known constraints and assumptions
+
+Software description: <Describe the software item>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Functional Software Safety Requirements
+
+[TEXT]
+STATEMENT: >>>
+Software safety requirements derived from the SRS safety functions.
+Each requirement shall be unambiguous, verifiable, complete, and consistent.
+<<<
+
+[REQUIREMENT]
+UID: SSRS-010
+STATUS: Draft
+TITLE: <Software safety function 1>
+STATEMENT: >>>
+SAFETY_FUNCTION: SF-1
+The software shall <describe the software behaviour required to realise
+the safety function, including: inputs monitored, logic applied, outputs
+commanded, timing constraints>.
+
+Input signals: <list>
+Output signals: <list>
+Response time: < <value> ms from input detection to output activation.
+Safe output state: <define>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing, Analysis
+RATIONALE: >>>
+Derived from SRS-010. This requirement implements safety function SF-1.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SRS-010
+
+[REQUIREMENT]
+UID: SSRS-011
+STATUS: Draft
+TITLE: <Software safety function 2>
+STATEMENT: >>>
+SAFETY_FUNCTION: SF-2
+The software shall <describe the software behaviour for safety function 2>.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing, Analysis
+RELATIONS:
+- TYPE: Parent
+  VALUE: SRS-011
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Integrity Requirements
+
+[[SECTION]]
+TITLE: Software Development Process Requirements
+
+[REQUIREMENT]
+UID: SSRS-020
+STATUS: Draft
+TITLE: Software development lifecycle
+STATEMENT: >>>
+The software shall be developed in accordance with a defined software
+development lifecycle, covering requirements, design, implementation,
+testing, and validation phases, consistent with IEC 61508-3:2010, Figure 2.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 7.1.
+
+[REQUIREMENT]
+UID: SSRS-021
+STATUS: Draft
+TITLE: Software configuration management
+STATEMENT: >>>
+All software items, including source code, compiled artefacts, tools,
+test cases, and documentation, shall be placed under configuration
+management with version identification and change control.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.
+
+[REQUIREMENT]
+UID: SSRS-022
+STATUS: Draft
+TITLE: Bi-directional traceability
+STATEMENT: >>>
+Bi-directional traceability shall be maintained between:
+- Software safety requirements and system safety requirements (SRS).
+- Software safety requirements and software design elements.
+- Software safety requirements and test cases.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 7.2.2.6.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Architecture Requirements
+
+[REQUIREMENT]
+UID: SSRS-030
+STATUS: Draft
+TITLE: Modular software architecture
+STATEMENT: >>>
+The software architecture shall be structured into well-defined modules
+with clearly specified interfaces, minimising coupling between modules
+and maximising cohesion within each module.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.3 – Software architecture design.
+
+[REQUIREMENT]
+UID: SSRS-031
+STATUS: Draft
+TITLE: Data flow and control flow definition
+STATEMENT: >>>
+The software architecture shall explicitly define all data flows and
+control flows between software modules, including timing and sequencing
+of safety-relevant operations.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection, Analysis
+
+[REQUIREMENT]
+UID: SSRS-032
+STATUS: Draft
+TITLE: Error detection at architectural level
+STATEMENT: >>>
+The software architecture shall incorporate mechanisms for detection and
+handling of errors, including:
+- Input data range and plausibility checks
+- Internal state consistency checks
+- Output monitoring / output cross-checking (if applicable)
+- Watchdog supervision
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection, Testing
+RATIONALE: IEC 61508-3:2010, Table A.3 – Error detection and correction.
+
+[REQUIREMENT]
+UID: SSRS-033
+STATUS: Draft
+TITLE: Diverse software redundancy
+STATEMENT: >>>
+Where software redundancy is used to achieve the required SIL, the
+redundant software channels shall be developed independently (different
+design team, different tools, or diverse design methods) to avoid
+systematic common cause failures.
+<<<
+SIL_1: --
+SIL_2: NR
+SIL_3: R
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 7.4.7 and Table A.3.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Design and Coding Requirements
+
+[REQUIREMENT]
+UID: SSRS-040
+STATUS: Draft
+TITLE: Structured programming
+STATEMENT: >>>
+The software shall be implemented using structured programming techniques.
+The use of unrestricted recursion, dynamic memory allocation after
+initialisation, and unrestricted use of pointers shall be prohibited.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.4 – Software design and coding standards.
+
+[REQUIREMENT]
+UID: SSRS-041
+STATUS: Draft
+TITLE: Coding standard
+STATEMENT: >>>
+A defined coding standard appropriate to the target SIL shall be applied
+throughout the software implementation. Deviations from the coding standard
+shall be documented and justified.
+
+Applicable standard: <e.g. MISRA C:2012, CERT C, project-specific standard>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.4.
+
+[REQUIREMENT]
+UID: SSRS-042
+STATUS: Draft
+TITLE: Use of language subset
+STATEMENT: >>>
+A defined, restricted subset of the programming language shall be used,
+excluding language features that are prone to ambiguity, implementation-
+defined or undefined behaviour, or difficult to verify.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.4 – Language subset.
+
+[REQUIREMENT]
+UID: SSRS-043
+STATUS: Draft
+TITLE: Defensive programming
+STATEMENT: >>>
+Defensive programming techniques shall be applied, including:
+- Validation of all external inputs (range, type, plausibility)
+- Assertion-based checks on preconditions and postconditions
+  of safety-relevant functions
+- Safe defaults for initialisation of all variables
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection, Testing
+RATIONALE: IEC 61508-3:2010, Table A.4 – Defensive programming.
+
+[REQUIREMENT]
+UID: SSRS-044
+STATUS: Draft
+TITLE: Formal methods for specification and design
+STATEMENT: >>>
+Formal methods (e.g. Z, VDM, B-Method, or equivalent) shall be applied
+to the specification and/or design of safety-critical software modules,
+where practicable, to provide mathematical proof of properties.
+<<<
+SIL_1: --
+SIL_2: NR
+SIL_3: R
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.4 – Formal methods.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Verification Requirements
+
+[REQUIREMENT]
+UID: SSRS-050
+STATUS: Draft
+TITLE: Static analysis
+STATEMENT: >>>
+Static analysis shall be applied to the software source code to detect
+defects including: unreachable code, uninitialised variables, stack
+overflow potential, coding standard violations.
+Tool: <specify tool>
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Analysis
+RATIONALE: IEC 61508-3:2010, Table A.8 – Software module testing and integration.
+
+[REQUIREMENT]
+UID: SSRS-051
+STATUS: Draft
+TITLE: Structural test coverage
+STATEMENT: >>>
+Structural test coverage analysis shall demonstrate the following coverage
+levels for safety-relevant software modules:
+- SIL 1/2: Statement coverage (MC/DC not required).
+- SIL 3:   Branch coverage (decision coverage).
+- SIL 4:   Modified Condition / Decision Coverage (MC/DC).
+
+Coverage tool: <specify tool>
+<<<
+SIL_1: R
+SIL_2: R
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing, Analysis
+RATIONALE: IEC 61508-3:2010, Table A.8.
+
+[REQUIREMENT]
+UID: SSRS-052
+STATUS: Draft
+TITLE: Software integration testing
+STATEMENT: >>>
+Software integration testing shall verify the correct interaction between
+software modules and between software and hardware, including:
+- Interface testing
+- Timing and performance testing
+- Error handling under fault injection
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+RATIONALE: IEC 61508-3:2010, Clause 7.7.
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-3:2010, Clause 7.2 – Software safety requirements specification.
+[2] IEC 61508-3:2010, Tables A.1–A.10 – Techniques and measures.
+[3] <Document ID> – Safety Requirements Specification (SRS).
+[4] <Project-specific references>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Software Safety Requirements Specification
+TITLE: Software safety requirements specification
 OPTIONS:
   MARKUP: Text
 
@@ -29,7 +29,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -49,7 +49,7 @@ SRS Reference:   <Document ID of Safety Requirements Specification>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Overview
+TITLE: Software overview
 
 [TEXT]
 STATEMENT: >>>
@@ -67,7 +67,7 @@ Software description: <Describe the software item>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Functional Software Safety Requirements
+TITLE: Functional software safety requirements
 
 [TEXT]
 STATEMENT: >>>
@@ -122,10 +122,10 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Integrity Requirements
+TITLE: Software integrity requirements
 
 [[SECTION]]
-TITLE: Software Development Process Requirements
+TITLE: Software development process requirements
 
 [REQUIREMENT]
 UID: SSRS-020
@@ -179,7 +179,7 @@ RATIONALE: IEC 61508-3:2010, Clause 7.2.2.6.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Architecture Requirements
+TITLE: Software architecture requirements
 
 [REQUIREMENT]
 UID: SSRS-030
@@ -251,7 +251,7 @@ RATIONALE: IEC 61508-3:2010, Clause 7.4.7 and Table A.3.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Design and Coding Requirements
+TITLE: Software design and coding requirements
 
 [REQUIREMENT]
 UID: SSRS-040
@@ -340,7 +340,7 @@ RATIONALE: IEC 61508-3:2010, Table A.4 – Formal methods.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Verification Requirements
+TITLE: Software verification requirements
 
 [REQUIREMENT]
 UID: SSRS-050

--- a/templates/iec-61508-3/05_sw_design_spec.sdoc
+++ b/templates/iec-61508-3/05_sw_design_spec.sdoc
@@ -1,0 +1,323 @@
+[DOCUMENT]
+TITLE: Software Design Specification
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document is the Software Design Specification (SDS) for the software element
+of the E/E/PE safety-related system identified below. It covers both the software
+architecture design and the detailed design, in accordance with
+IEC 61508-3:2010, Clauses 7.3 and 7.4.
+
+SIL_1 through SIL_4 fields classify design requirements as HR/R/NR/--
+per IEC 61508-3:2010 Tables A.3 and A.4.
+
+Instructions for use:
+- UIDs follow convention: SDS-xxx.
+- Architecture requirements trace to SSRS via RELATIONS (Parent: SSRS-xxx).
+- Detailed design requirements trace to architecture requirements.
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+Software Item:   <Software item / component name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
+SSRS Reference:  <Document ID of Software Safety Requirements Specification>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Architecture Design
+
+[TEXT]
+STATEMENT: >>>
+This section defines the software architecture in accordance with
+IEC 61508-3:2010, Clause 7.3. It shall demonstrate that the architecture
+is capable of realising the software safety requirements specified in the SSRS.
+<<<
+
+[[SECTION]]
+TITLE: Architectural Overview
+
+[REQUIREMENT]
+UID: SDS-010
+STATUS: Draft
+TITLE: Software architecture description
+STATEMENT: >>>
+The software shall be partitioned into the following modules / components:
+
+<Module 1>: <purpose and responsibilities>
+<Module 2>: <purpose and responsibilities>
+<Module 3 – Safety Monitor>: <purpose and responsibilities>
+
+The architecture shall enforce separation between safety-relevant and
+non-safety-relevant software elements through <describe partitioning
+mechanism: memory protection, separate tasks, separate processors, etc.>.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-030
+
+[REQUIREMENT]
+UID: SDS-011
+STATUS: Draft
+TITLE: Software / hardware interface definition
+STATEMENT: >>>
+The software architecture shall define all hardware interfaces, including:
+- Input signal acquisition: <describe I/O registers, interrupt handling, DMA>
+- Output signal command: <describe output registers, actuation paths>
+- Diagnostic interfaces: <describe watchdog, BITE, BIT>
+- Communication interfaces: <describe protocols, message formats>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection, Testing
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-031
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Data Flow and Control Flow
+
+[REQUIREMENT]
+UID: SDS-020
+STATUS: Draft
+TITLE: Data flow definition
+STATEMENT: >>>
+The data flow between software modules shall be defined, specifying:
+- All data items exchanged between modules
+- Data type, range, and units for each safety-relevant data item
+- Direction of data flow
+- Protection mechanisms for shared data (e.g. semaphores, double-buffering)
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-031
+
+[REQUIREMENT]
+UID: SDS-021
+STATUS: Draft
+TITLE: Control flow definition
+STATEMENT: >>>
+The control flow of the software shall be defined, including:
+- Task/thread scheduling model and priorities
+- Execution sequence for safety-critical paths
+- Interrupt handling and preemption policy
+- Timing constraints for safety-relevant tasks
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection, Analysis
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Error Handling and Fault Tolerance
+
+[REQUIREMENT]
+UID: SDS-030
+STATUS: Draft
+TITLE: Input validation architecture
+STATEMENT: >>>
+The software architecture shall include an input validation stage that
+performs the following checks before any safety-relevant processing:
+- Range check: all inputs within declared safe operating range
+- Rate-of-change check: inputs do not change faster than physically plausible
+- Cross-channel comparison (if redundant inputs are present)
+- Signal timeout detection
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing, Inspection
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-032
+
+[REQUIREMENT]
+UID: SDS-031
+STATUS: Draft
+TITLE: Watchdog supervision
+STATEMENT: >>>
+An independent watchdog mechanism shall supervise the correct execution
+of the safety-relevant software. The watchdog shall:
+- Require periodic servicing by all safety-critical execution paths.
+- Drive the system to a safe state if not serviced within <timeout> ms.
+- Be implemented in hardware or in a processor independent from the
+  supervised software.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-032
+
+[REQUIREMENT]
+UID: SDS-032
+STATUS: Draft
+TITLE: Safe state transition
+STATEMENT: >>>
+Upon detection of any safety-relevant fault, the software shall perform
+a controlled transition to the defined safe state, including:
+- Commanding safe output states within the required response time.
+- Inhibiting further actuation commands.
+- Logging fault information to non-volatile memory (if applicable).
+- Activating diagnostic / alarm outputs.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-032
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Detailed Design
+
+[TEXT]
+STATEMENT: >>>
+This section defines the detailed design of safety-relevant software modules in
+accordance with IEC 61508-3:2010, Clause 7.4. For each module, the following
+shall be defined:
+- Module purpose and safety responsibilities
+- Interface specification (inputs, outputs, pre/post conditions)
+- Internal logic description (pseudo-code, flowchart, or state machine)
+- Error handling behaviour
+- Resource usage (stack depth, timing budget)
+<<<
+
+[[SECTION]]
+TITLE: Module: <Safety-Critical Module Name>
+
+[REQUIREMENT]
+UID: SDS-100
+STATUS: Draft
+TITLE: <Module name> – interface specification
+STATEMENT: >>>
+Module: <Name>
+Purpose: <Describe the module's role in the safety function>
+
+Inputs:
+  <signal_name> : <type>, range [<min>..<max>], unit <unit>
+  <signal_name> : <type>, range [<min>..<max>], unit <unit>
+
+Outputs:
+  <signal_name> : <type>, range [<min>..<max>], unit <unit>
+
+Preconditions:  <Conditions that must hold before calling this module>
+Postconditions: <Guarantees provided by this module upon return>
+
+Timing budget: <max execution time> µs (worst case)
+Stack usage:   <max bytes>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection, Analysis
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDS-010
+
+[REQUIREMENT]
+UID: SDS-101
+STATUS: Draft
+TITLE: <Module name> – logic description
+STATEMENT: >>>
+The processing logic of <module name> shall implement the following behaviour:
+
+<Describe using pseudo-code, structured English, or reference to a design
+diagram. For SIL 3/4 consider using a formal notation such as state tables
+or a subset of UML statecharts.>
+
+Step 1: <Acquire and validate inputs>
+Step 2: <Execute safety logic>
+Step 3: <Command outputs or signal safe state>
+Step 4: <Log diagnostic data>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDS-100
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Design Verification Summary
+
+[TEXT]
+STATEMENT: >>>
+This section summarises the design verification activities planned or performed
+in accordance with IEC 61508-3:2010, Clause 7.5.
+
+Verification method  | Applicable to    | Standard reference
+---------------------|------------------|----------------------
+Walk-through         | Architecture     | Table A.5 – SIL 1-4 HR
+Inspection/Review    | Detailed design  | Table A.5 – SIL 1-4 HR
+Formal proof         | Critical modules | Table A.5 – SIL 3/4 R/HR
+Simulation           | Timing analysis  | Table A.5 – SIL 1/2 R
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-3:2010, Clause 7.3 – Software architecture design.
+[2] IEC 61508-3:2010, Clause 7.4 – Software design and development.
+[3] IEC 61508-3:2010, Tables A.3 and A.4 – Techniques and measures.
+[4] <Document ID> – Software Safety Requirements Specification.
+[5] <Project-specific references>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/05_sw_design_spec.sdoc
+++ b/templates/iec-61508-3/05_sw_design_spec.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Software Design Specification
+TITLE: Software design specification
 OPTIONS:
   MARKUP: Text
 
@@ -24,7 +24,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -43,7 +43,7 @@ SSRS Reference:  <Document ID of Software Safety Requirements Specification>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Architecture Design
+TITLE: Software architecture design
 
 [TEXT]
 STATEMENT: >>>
@@ -53,7 +53,7 @@ is capable of realising the software safety requirements specified in the SSRS.
 <<<
 
 [[SECTION]]
-TITLE: Architectural Overview
+TITLE: Architectural overview
 
 [REQUIREMENT]
 UID: SDS-010
@@ -102,7 +102,7 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Data Flow and Control Flow
+TITLE: Data flow and control flow
 
 [REQUIREMENT]
 UID: SDS-020
@@ -144,7 +144,7 @@ VERIFICATION_METHOD: Inspection, Analysis
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Error Handling and Fault Tolerance
+TITLE: Error handling and fault tolerance
 
 [REQUIREMENT]
 UID: SDS-030
@@ -214,7 +214,7 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Detailed Design
+TITLE: Detailed design
 
 [TEXT]
 STATEMENT: >>>
@@ -291,7 +291,7 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Design Verification Summary
+TITLE: Design verification summary
 
 [TEXT]
 STATEMENT: >>>

--- a/templates/iec-61508-3/06_sw_test_spec_report.sdoc
+++ b/templates/iec-61508-3/06_sw_test_spec_report.sdoc
@@ -1,0 +1,434 @@
+[DOCUMENT]
+TITLE: Software Test Specification and Report
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document is the Software Test Specification and Test Report for the software
+element of the E/E/PE safety-related system identified below. It is prepared in
+accordance with IEC 61508-3:2010, Clauses 7.7 (Software module testing and
+integration) and 7.8 (Programmable electronics integration testing).
+
+The document serves both as a test specification (test cases defined prior to
+execution) and a test report (results recorded after execution). Each test case
+uses a single REQUIREMENT node; the COMMENT field records the execution result.
+
+SIL_1 through SIL_4 fields classify each test technique as HR/R/NR/--
+per IEC 61508-3:2010 Table A.8.
+
+Instructions for use:
+- UIDs follow convention: STS-xxx (specification), STR-xxx (result records).
+- Each test case traces to the SSRS or SDS requirement it verifies.
+- STATUS should be set to Draft initially, then Active when the test is approved,
+  then reference results in COMMENT once executed.
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+Software Item:   <Software item / component name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
+SSRS Reference:  <Document ID of Software Safety Requirements Specification>
+SDS Reference:   <Document ID of Software Design Specification>
+Test Environment: <Hardware platform, OS, toolchain, test framework version>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Test Strategy
+
+[TEXT]
+STATEMENT: >>>
+Describe the overall test strategy and the levels of testing performed.
+The test levels shall address all requirements in the SSRS and SDS.
+
+Test levels:
+1. Software module (unit) testing – IEC 61508-3:2010, Clause 7.7.2
+2. Software integration testing  – IEC 61508-3:2010, Clause 7.7.3
+3. Software / hardware integration testing – IEC 61508-3:2010, Clause 7.8
+
+For each level, specify:
+- Scope and objectives
+- Entry and exit criteria
+- Test environment
+- Coverage target
+<<<
+
+[REQUIREMENT]
+UID: STS-001
+STATUS: Draft
+TITLE: Test coverage objective
+STATEMENT: >>>
+The following structural coverage levels shall be achieved for safety-relevant
+software modules:
+- SIL 1: Statement coverage ≥ 100%
+- SIL 2: Statement coverage ≥ 100%
+- SIL 3: Branch (decision) coverage ≥ 100%
+- SIL 4: MC/DC ≥ 100%
+
+Coverage tool: <specify tool and version>
+Measurement method: <describe how coverage is measured>
+<<<
+SIL_1: R
+SIL_2: R
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing, Analysis
+RATIONALE: IEC 61508-3:2010, Table A.8 – Software module testing.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Module (Unit) Tests
+
+[TEXT]
+STATEMENT: >>>
+Unit tests verify the correct behaviour of individual software modules in
+isolation, consistent with IEC 61508-3:2010, Clause 7.7.2.
+Test harnesses and stubs shall be documented.
+<<<
+
+[[SECTION]]
+TITLE: Module: <Safety-Critical Module Name> – Unit Tests
+
+[REQUIREMENT]
+UID: STS-100
+STATUS: Draft
+TITLE: <Module> – Normal operation test
+STATEMENT: >>>
+Test case: Verify correct output of <module name> for valid inputs within
+the nominal operating range.
+
+Preconditions: <Initialisation state, hardware state>
+
+Input stimulus:
+  <signal_name> = <value> (<unit>)
+  <signal_name> = <value> (<unit>)
+
+Expected result:
+  <output_name> = <expected value> ± <tolerance> (<unit>)
+  Execution time ≤ <value> µs
+  No error flag set.
+
+Pass criteria: All expected results within tolerance. No unexpected
+               state transitions or outputs.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Actual result: <describe actual outputs>
+Tester: <Name>
+Deviation: <None / describe deviation and reference NCR if applicable>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-010
+
+[REQUIREMENT]
+UID: STS-101
+STATUS: Draft
+TITLE: <Module> – Input boundary value test
+STATEMENT: >>>
+Test case: Verify correct output of <module name> at input boundary values
+(minimum, maximum, and just outside valid range).
+
+Input stimulus (minimum boundary):
+  <signal_name> = <min_value> (<unit>)
+Expected result: <expected output at minimum>
+
+Input stimulus (maximum boundary):
+  <signal_name> = <max_value> (<unit>)
+Expected result: <expected output at maximum>
+
+Input stimulus (below minimum – out of range):
+  <signal_name> = <min_value - 1> (<unit>)
+Expected result: Error flag set. Output commanded to safe state.
+
+Input stimulus (above maximum – out of range):
+  <signal_name> = <max_value + 1> (<unit>)
+Expected result: Error flag set. Output commanded to safe state.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Tester: <Name>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-043
+
+[REQUIREMENT]
+UID: STS-102
+STATUS: Draft
+TITLE: <Module> – Fault injection test (input out of range)
+STATEMENT: >>>
+Test case: Verify that <module name> correctly detects and handles an
+injected input fault (corrupted value beyond valid range).
+
+Fault injection method: <direct register write / stimulus override / fault
+                         injection tool>
+Injected fault: <signal_name> forced to <fault_value> (outside valid range)
+
+Expected result:
+  - Fault detected within <detection_time> ms.
+  - System transitions to safe state.
+  - Fault flag set in diagnostic memory.
+  - No spurious output activation.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Tester: <Name>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDS-030
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Integration Tests
+
+[TEXT]
+STATEMENT: >>>
+Integration tests verify the correct interaction between software modules,
+consistent with IEC 61508-3:2010, Clause 7.7.3.
+<<<
+
+[REQUIREMENT]
+UID: STS-200
+STATUS: Draft
+TITLE: Module interface integration test
+STATEMENT: >>>
+Test case: Verify correct data exchange across the interface between
+<Module A> and <Module B>.
+
+Preconditions: Both modules initialised. Shared data structures cleared.
+
+Test procedure:
+  Step 1: <Module A> writes <data_item> = <value> to shared memory.
+  Step 2: <Module B> reads <data_item> and processes it.
+  Step 3: Verify <Module B> output = <expected value>.
+
+Expected result: <Module B> produces correct output. No data corruption
+                 detected. Interface error counters = 0.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Tester: <Name>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDS-020
+
+[REQUIREMENT]
+UID: STS-201
+STATUS: Draft
+TITLE: Timing and scheduling integration test
+STATEMENT: >>>
+Test case: Verify that all safety-critical tasks meet their timing constraints
+under worst-case load conditions.
+
+Test procedure:
+  Step 1: Apply maximum input stimulus rate.
+  Step 2: Inject background load (non-safety tasks at maximum rate).
+  Step 3: Measure worst-case execution time (WCET) for each safety-critical task.
+  Step 4: Verify all tasks complete within their scheduling deadline.
+
+Expected result:
+  <Task 1> WCET ≤ <deadline_1> ms
+  <Task 2> WCET ≤ <deadline_2> ms
+  No deadline overruns. Watchdog not triggered.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing, Analysis
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Measured WCET values: <report measurements>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDS-021
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software / Hardware Integration Tests
+
+[TEXT]
+STATEMENT: >>>
+Software/hardware integration tests verify the correct behaviour of the software
+running on the target hardware platform, consistent with
+IEC 61508-3:2010, Clause 7.8.
+<<<
+
+[REQUIREMENT]
+UID: STS-300
+STATUS: Draft
+TITLE: Target hardware functional test – normal operation
+STATEMENT: >>>
+Test case: Verify correct end-to-end behaviour of the safety function on
+the target hardware platform under normal operating conditions.
+
+Test environment: <Target hardware, I/O simulator / real plant>
+
+Test procedure:
+  Step 1: Apply nominal process inputs via <I/O simulator / real signal>.
+  Step 2: Verify correct output commands within response time.
+  Step 3: Verify no spurious transitions to safe state.
+
+Expected result:
+  Safety function activated within ≤ <response_time> ms.
+  Output signal physically measured at ≥ <threshold> V / correct state.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Test configuration: <hardware revision, firmware version>
+Measured response time: <value> ms
+Tester: <Name>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-010
+
+[REQUIREMENT]
+UID: STS-301
+STATUS: Draft
+TITLE: Watchdog self-test verification
+STATEMENT: >>>
+Test case: Verify that the watchdog mechanism correctly detects software
+execution failure and drives the system to the safe state.
+
+Test procedure:
+  Step 1: Disable watchdog servicing by inhibiting the servicing task.
+  Step 2: Wait for watchdog timeout period (<timeout> ms).
+  Step 3: Verify system transitions to safe state.
+  Step 4: Verify safe outputs are in correct state.
+  Step 5: Verify fault log entry created.
+
+Expected result: Safe state reached within <timeout + margin> ms.
+                 No false recovery without explicit reset.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Testing
+COMMENT: >>>
+Result: <PASS / FAIL / NOT RUN>
+Date executed: <YYYY-MM-DD>
+Tester: <Name>
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDS-031
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Test Coverage Summary
+
+[TEXT]
+STATEMENT: >>>
+Record the structural coverage results achieved after completion of all
+module tests. Coverage shall meet the targets defined in STS-001.
+
+Module              | Statements | Branches | MC/DC  | Coverage tool
+--------------------|------------|----------|--------|---------------
+<Module 1>          |   100%     |   100%   |  N/A   | <tool>
+<Module 2>          |   100%     |   100%   |  95%   | <tool>
+<Safety Monitor>    |   100%     |   100%   |  100%  | <tool>
+
+Overall result: PASS / FAIL
+Uncovered items: <List any intentionally excluded code with justification>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Outstanding Issues and Non-Conformance Reports
+
+[TEXT]
+STATEMENT: >>>
+List all open test failures, deviations, and non-conformance reports (NCRs)
+identified during testing. All open items shall be resolved before
+software safety validation is declared complete.
+<<<
+
+[ACTION_ITEM]
+UID: NCR-001
+STATUS: Open
+TITLE: <Short description of test failure or NCR>
+STATEMENT: >>>
+Test case: <STS-xxx>
+Failure description: <Describe the observed failure>
+Impact on safety: <Describe the safety impact>
+Proposed resolution: <Describe the proposed corrective action>
+<<<
+OWNER: <Name>
+DUE_DATE: <YYYY-MM-DD>
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-3:2010, Clause 7.7 – Software module testing and integration.
+[2] IEC 61508-3:2010, Clause 7.8 – Programmable electronics integration testing.
+[3] IEC 61508-3:2010, Table A.8 – Techniques and measures for testing.
+[4] <Document ID> – Software Safety Requirements Specification.
+[5] <Document ID> – Software Design Specification.
+[6] <Project-specific references>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/06_sw_test_spec_report.sdoc
+++ b/templates/iec-61508-3/06_sw_test_spec_report.sdoc
@@ -13,18 +13,23 @@ element of the E/E/PE safety-related system identified below. It is prepared in
 accordance with IEC 61508-3:2010, Clauses 7.7 (Software module testing and
 integration) and 7.8 (Programmable electronics integration testing).
 
-The document serves both as a test specification (test cases defined prior to
-execution) and a test report (results recorded after execution). Each test case
-uses a single REQUIREMENT node; the COMMENT field records the execution result.
+Each test case is recorded as a TEST_CASE node. The RELATIONS field uses
+ROLE: Verifies to establish explicit traceability to the SSRS or SDS requirement
+being verified. This allows StrictDoc to generate a dedicated verification
+traceability matrix distinct from the hierarchical parent-child relationships.
 
-SIL_1 through SIL_4 fields classify each test technique as HR/R/NR/--
-per IEC 61508-3:2010 Table A.8.
+TEST_TYPE values:
+  Unit             - single software module in isolation
+  Integration      - interaction between software modules
+  HW-SW-Integration - software on target hardware
+  Validation       - end-to-end safety function validation
+
+VERDICT values: PASS / FAIL / NOT_RUN / BLOCKED
 
 Instructions for use:
-- UIDs follow convention: STS-xxx (specification), STR-xxx (result records).
-- Each test case traces to the SSRS or SDS requirement it verifies.
-- STATUS should be set to Draft initially, then Active when the test is approved,
-  then reference results in COMMENT once executed.
+- UIDs follow convention: TC-xxx.
+- Fill ACTUAL_RESULT and VERDICT after test execution.
+- Leave VERDICT as NOT_RUN before execution.
 - Delete this instruction block before formal release.
 <<<
 
@@ -40,7 +45,6 @@ Revision:        <Rev. A>
 Date:            <YYYY-MM-DD>
 Author:          <Name, Role>
 Approved by:     <Name, Role>
-Classification:  <Confidential / Restricted / Public>
 Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
 SSRS Reference:  <Document ID of Software Safety Requirements Specification>
 SDS Reference:   <Document ID of Software Design Specification>
@@ -54,322 +58,236 @@ TITLE: Test Strategy
 
 [TEXT]
 STATEMENT: >>>
-Describe the overall test strategy and the levels of testing performed.
-The test levels shall address all requirements in the SSRS and SDS.
-
 Test levels:
-1. Software module (unit) testing – IEC 61508-3:2010, Clause 7.7.2
-2. Software integration testing  – IEC 61508-3:2010, Clause 7.7.3
-3. Software / hardware integration testing – IEC 61508-3:2010, Clause 7.8
+1. Unit testing        - IEC 61508-3:2010, Clause 7.7.2
+2. Integration testing - IEC 61508-3:2010, Clause 7.7.3
+3. HW-SW integration   - IEC 61508-3:2010, Clause 7.8
 
-For each level, specify:
-- Scope and objectives
-- Entry and exit criteria
-- Test environment
-- Coverage target
+Coverage target per SIL (IEC 61508-3:2010 Table A.8):
+  SIL 1/2: Statement coverage >= 100%
+  SIL 3:   Branch coverage >= 100%
+  SIL 4:   MC/DC >= 100%
 <<<
-
-[REQUIREMENT]
-UID: STS-001
-STATUS: Draft
-TITLE: Test coverage objective
-STATEMENT: >>>
-The following structural coverage levels shall be achieved for safety-relevant
-software modules:
-- SIL 1: Statement coverage ≥ 100%
-- SIL 2: Statement coverage ≥ 100%
-- SIL 3: Branch (decision) coverage ≥ 100%
-- SIL 4: MC/DC ≥ 100%
-
-Coverage tool: <specify tool and version>
-Measurement method: <describe how coverage is measured>
-<<<
-SIL_1: R
-SIL_2: R
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing, Analysis
-RATIONALE: IEC 61508-3:2010, Table A.8 – Software module testing.
 
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Module (Unit) Tests
+TITLE: Unit Tests
 
-[TEXT]
-STATEMENT: >>>
-Unit tests verify the correct behaviour of individual software modules in
-isolation, consistent with IEC 61508-3:2010, Clause 7.7.2.
-Test harnesses and stubs shall be documented.
-<<<
-
-[[SECTION]]
-TITLE: Module: <Safety-Critical Module Name> – Unit Tests
-
-[REQUIREMENT]
-UID: STS-100
+[TEST_CASE]
+UID: TC-001
 STATUS: Draft
-TITLE: <Module> – Normal operation test
-STATEMENT: >>>
-Test case: Verify correct output of <module name> for valid inputs within
-the nominal operating range.
-
-Preconditions: <Initialisation state, hardware state>
-
-Input stimulus:
-  <signal_name> = <value> (<unit>)
-  <signal_name> = <value> (<unit>)
-
-Expected result:
-  <output_name> = <expected value> ± <tolerance> (<unit>)
-  Execution time ≤ <value> µs
-  No error flag set.
-
-Pass criteria: All expected results within tolerance. No unexpected
-               state transitions or outputs.
+TITLE: <Module> - normal operation
+TEST_TYPE: Unit
+PRECONDITIONS: >>>
+<Initial state of the module under test and required initialisation.>
 <<<
-SIL_1: HR
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Actual result: <describe actual outputs>
-Tester: <Name>
-Deviation: <None / describe deviation and reference NCR if applicable>
+STEPS: >>>
+Step 1: Set inputs: <signal_name> = <value> (<unit>)
+Step 2: Execute module
+Step 3: Read outputs
 <<<
+EXPECTED_RESULT: >>>
+<output_name> = <expected value> +/- <tolerance>
+Execution time <= <value> us
+No error flag set.
+<<<
+ACTUAL_RESULT: >>>
+<Fill after execution>
+<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
 RELATIONS:
 - TYPE: Parent
   VALUE: SSRS-010
+  ROLE: Verifies
 
-[REQUIREMENT]
-UID: STS-101
+[TEST_CASE]
+UID: TC-002
 STATUS: Draft
-TITLE: <Module> – Input boundary value test
-STATEMENT: >>>
-Test case: Verify correct output of <module name> at input boundary values
-(minimum, maximum, and just outside valid range).
-
-Input stimulus (minimum boundary):
-  <signal_name> = <min_value> (<unit>)
-Expected result: <expected output at minimum>
-
-Input stimulus (maximum boundary):
-  <signal_name> = <max_value> (<unit>)
-Expected result: <expected output at maximum>
-
-Input stimulus (below minimum – out of range):
-  <signal_name> = <min_value - 1> (<unit>)
-Expected result: Error flag set. Output commanded to safe state.
-
-Input stimulus (above maximum – out of range):
-  <signal_name> = <max_value + 1> (<unit>)
-Expected result: Error flag set. Output commanded to safe state.
+TITLE: <Module> - boundary value at minimum
+TEST_TYPE: Unit
+PRECONDITIONS: >>>
+<Same initial state as TC-001.>
 <<<
-SIL_1: HR
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Tester: <Name>
+STEPS: >>>
+Step 1: Set input to minimum valid value
+Step 2: Execute module
+Step 3: Read outputs
 <<<
-RELATIONS:
-- TYPE: Parent
-  VALUE: SSRS-043
-
-[REQUIREMENT]
-UID: STS-102
-STATUS: Draft
-TITLE: <Module> – Fault injection test (input out of range)
-STATEMENT: >>>
-Test case: Verify that <module name> correctly detects and handles an
-injected input fault (corrupted value beyond valid range).
-
-Fault injection method: <direct register write / stimulus override / fault
-                         injection tool>
-Injected fault: <signal_name> forced to <fault_value> (outside valid range)
-
-Expected result:
-  - Fault detected within <detection_time> ms.
-  - System transitions to safe state.
-  - Fault flag set in diagnostic memory.
-  - No spurious output activation.
+EXPECTED_RESULT: >>>
+Output matches expected value at lower boundary.
+No error flag set.
 <<<
-SIL_1: R
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Tester: <Name>
+ACTUAL_RESULT: >>>
+<Fill after execution>
 <<<
-RELATIONS:
-- TYPE: Parent
-  VALUE: SDS-030
-
-[[/SECTION]]
-
-[[/SECTION]]
-
-[[SECTION]]
-TITLE: Software Integration Tests
-
-[TEXT]
-STATEMENT: >>>
-Integration tests verify the correct interaction between software modules,
-consistent with IEC 61508-3:2010, Clause 7.7.3.
-<<<
-
-[REQUIREMENT]
-UID: STS-200
-STATUS: Draft
-TITLE: Module interface integration test
-STATEMENT: >>>
-Test case: Verify correct data exchange across the interface between
-<Module A> and <Module B>.
-
-Preconditions: Both modules initialised. Shared data structures cleared.
-
-Test procedure:
-  Step 1: <Module A> writes <data_item> = <value> to shared memory.
-  Step 2: <Module B> reads <data_item> and processes it.
-  Step 3: Verify <Module B> output = <expected value>.
-
-Expected result: <Module B> produces correct output. No data corruption
-                 detected. Interface error counters = 0.
-<<<
-SIL_1: HR
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Tester: <Name>
-<<<
-RELATIONS:
-- TYPE: Parent
-  VALUE: SDS-020
-
-[REQUIREMENT]
-UID: STS-201
-STATUS: Draft
-TITLE: Timing and scheduling integration test
-STATEMENT: >>>
-Test case: Verify that all safety-critical tasks meet their timing constraints
-under worst-case load conditions.
-
-Test procedure:
-  Step 1: Apply maximum input stimulus rate.
-  Step 2: Inject background load (non-safety tasks at maximum rate).
-  Step 3: Measure worst-case execution time (WCET) for each safety-critical task.
-  Step 4: Verify all tasks complete within their scheduling deadline.
-
-Expected result:
-  <Task 1> WCET ≤ <deadline_1> ms
-  <Task 2> WCET ≤ <deadline_2> ms
-  No deadline overruns. Watchdog not triggered.
-<<<
-SIL_1: R
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing, Analysis
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Measured WCET values: <report measurements>
-<<<
-RELATIONS:
-- TYPE: Parent
-  VALUE: SDS-021
-
-[[/SECTION]]
-
-[[SECTION]]
-TITLE: Software / Hardware Integration Tests
-
-[TEXT]
-STATEMENT: >>>
-Software/hardware integration tests verify the correct behaviour of the software
-running on the target hardware platform, consistent with
-IEC 61508-3:2010, Clause 7.8.
-<<<
-
-[REQUIREMENT]
-UID: STS-300
-STATUS: Draft
-TITLE: Target hardware functional test – normal operation
-STATEMENT: >>>
-Test case: Verify correct end-to-end behaviour of the safety function on
-the target hardware platform under normal operating conditions.
-
-Test environment: <Target hardware, I/O simulator / real plant>
-
-Test procedure:
-  Step 1: Apply nominal process inputs via <I/O simulator / real signal>.
-  Step 2: Verify correct output commands within response time.
-  Step 3: Verify no spurious transitions to safe state.
-
-Expected result:
-  Safety function activated within ≤ <response_time> ms.
-  Output signal physically measured at ≥ <threshold> V / correct state.
-<<<
-SIL_1: HR
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Test configuration: <hardware revision, firmware version>
-Measured response time: <value> ms
-Tester: <Name>
-<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
 RELATIONS:
 - TYPE: Parent
   VALUE: SSRS-010
+  ROLE: Verifies
 
-[REQUIREMENT]
-UID: STS-301
+[TEST_CASE]
+UID: TC-003
 STATUS: Draft
-TITLE: Watchdog self-test verification
-STATEMENT: >>>
-Test case: Verify that the watchdog mechanism correctly detects software
-execution failure and drives the system to the safe state.
-
-Test procedure:
-  Step 1: Disable watchdog servicing by inhibiting the servicing task.
-  Step 2: Wait for watchdog timeout period (<timeout> ms).
-  Step 3: Verify system transitions to safe state.
-  Step 4: Verify safe outputs are in correct state.
-  Step 5: Verify fault log entry created.
-
-Expected result: Safe state reached within <timeout + margin> ms.
-                 No false recovery without explicit reset.
+TITLE: <Module> - input out of range (fault injection)
+TEST_TYPE: Unit
+PRECONDITIONS: >>>
+<Initial state. Fault injection via direct variable override.>
 <<<
-SIL_1: R
-SIL_2: HR
-SIL_3: HR
-SIL_4: HR
-VERIFICATION_METHOD: Testing
-COMMENT: >>>
-Result: <PASS / FAIL / NOT RUN>
-Date executed: <YYYY-MM-DD>
-Tester: <Name>
+STEPS: >>>
+Step 1: Force input to value outside valid range
+Step 2: Execute module
+Step 3: Read outputs and error flags
 <<<
+EXPECTED_RESULT: >>>
+Safe state commanded (output DE-ENERGISED).
+Error flag set within one execution cycle.
+No spurious output activation.
+<<<
+ACTUAL_RESULT: >>>
+<Fill after execution>
+<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
 RELATIONS:
 - TYPE: Parent
-  VALUE: SDS-031
+  VALUE: SSRS-021
+  ROLE: Verifies
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Integration Tests
+
+[TEST_CASE]
+UID: TC-100
+STATUS: Draft
+TITLE: Module interface - data exchange
+TEST_TYPE: Integration
+PRECONDITIONS: >>>
+Both modules initialised. Shared data structures cleared.
+<<<
+STEPS: >>>
+Step 1: Module A writes <data_item> = <value> to shared structure
+Step 2: Trigger Module B execution
+Step 3: Read Module B output
+<<<
+EXPECTED_RESULT: >>>
+Module B output = <expected value>.
+Interface error counter = 0.
+No data corruption.
+<<<
+ACTUAL_RESULT: >>>
+<Fill after execution>
+<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-020
+  ROLE: Verifies
+
+[TEST_CASE]
+UID: TC-101
+STATUS: Draft
+TITLE: Timing - safety task meets deadline under full load
+TEST_TYPE: Integration
+PRECONDITIONS: >>>
+All non-safety tasks running at maximum stimulus rate.
+<<<
+STEPS: >>>
+Step 1: Apply maximum input stimulus rate
+Step 2: Run non-safety tasks at maximum load
+Step 3: Measure WCET of safety-critical task over 1000 cycles
+Step 4: Verify all cycles complete within deadline
+<<<
+EXPECTED_RESULT: >>>
+Safety task WCET <= <deadline> ms in all 1000 cycles.
+No watchdog trigger. No deadline overruns.
+<<<
+ACTUAL_RESULT: >>>
+<Fill after execution>
+<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-020
+  ROLE: Verifies
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: HW-SW Integration Tests
+
+[TEST_CASE]
+UID: TC-200
+STATUS: Draft
+TITLE: Safety function - end-to-end trip on target hardware
+TEST_TYPE: HW-SW-Integration
+PRECONDITIONS: >>>
+Target hardware powered. Firmware loaded (release build).
+I/O simulator connected. System in NORMAL state.
+<<<
+STEPS: >>>
+Step 1: Apply nominal input (below trip threshold). Verify no trip.
+Step 2: Step input to trip threshold value.
+Step 3: Measure time from step to safe state activation.
+Step 4: Verify output physically in safe state.
+<<<
+EXPECTED_RESULT: >>>
+No trip below threshold.
+Safe state activated within <= <response_time> ms.
+SAFETY_STATE = TRIPPED.
+<<<
+ACTUAL_RESULT: >>>
+<Fill after execution>
+<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-010
+  ROLE: Verifies
+
+[TEST_CASE]
+UID: TC-201
+STATUS: Draft
+TITLE: Watchdog - safe state on execution failure
+TEST_TYPE: HW-SW-Integration
+PRECONDITIONS: >>>
+Target hardware powered. Firmware loaded. System in NORMAL state.
+<<<
+STEPS: >>>
+Step 1: Inhibit watchdog servicing via debug interface
+Step 2: Wait watchdog timeout + 50 ms margin
+Step 3: Measure output state
+Step 4: Verify fault log in non-volatile memory
+<<<
+EXPECTED_RESULT: >>>
+Output physically in safe state.
+MCU reset observed.
+Fault log entry created.
+<<<
+ACTUAL_RESULT: >>>
+<Fill after execution>
+<<<
+VERDICT: NOT_RUN
+DATE_EXECUTED: <YYYY-MM-DD>
+TESTER: <Name>
+RELATIONS:
+- TYPE: Parent
+  VALUE: SSRS-020
+  ROLE: Verifies
 
 [[/SECTION]]
 
@@ -378,40 +296,29 @@ TITLE: Test Coverage Summary
 
 [TEXT]
 STATEMENT: >>>
-Record the structural coverage results achieved after completion of all
-module tests. Coverage shall meet the targets defined in STS-001.
+Module              | Statements | Branches | MC/DC  | Tool
+--------------------|------------|----------|--------|--------
+<Module 1>          | <xx%>      | <xx%>    | N/A    | <tool>
+<Safety Module>     | <xx%>      | <xx%>    | <xx%>  | <tool>
 
-Module              | Statements | Branches | MC/DC  | Coverage tool
---------------------|------------|----------|--------|---------------
-<Module 1>          |   100%     |   100%   |  N/A   | <tool>
-<Module 2>          |   100%     |   100%   |  95%   | <tool>
-<Safety Monitor>    |   100%     |   100%   |  100%  | <tool>
-
-Overall result: PASS / FAIL
-Uncovered items: <List any intentionally excluded code with justification>
+Overall result: <PASS / FAIL>
+Uncovered items: <None / describe with justification>
 <<<
 
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Outstanding Issues and Non-Conformance Reports
-
-[TEXT]
-STATEMENT: >>>
-List all open test failures, deviations, and non-conformance reports (NCRs)
-identified during testing. All open items shall be resolved before
-software safety validation is declared complete.
-<<<
+TITLE: Outstanding Issues
 
 [ACTION_ITEM]
 UID: NCR-001
 STATUS: Open
-TITLE: <Short description of test failure or NCR>
+TITLE: <Short description of open issue>
 STATEMENT: >>>
-Test case: <STS-xxx>
-Failure description: <Describe the observed failure>
-Impact on safety: <Describe the safety impact>
-Proposed resolution: <Describe the proposed corrective action>
+Test case: <TC-xxx>
+Failure description: <Describe observed failure>
+Safety impact: <Describe impact>
+Proposed resolution: <Describe corrective action>
 <<<
 OWNER: <Name>
 DUE_DATE: <YYYY-MM-DD>
@@ -423,12 +330,11 @@ TITLE: References
 
 [TEXT]
 STATEMENT: >>>
-[1] IEC 61508-3:2010, Clause 7.7 – Software module testing and integration.
-[2] IEC 61508-3:2010, Clause 7.8 – Programmable electronics integration testing.
-[3] IEC 61508-3:2010, Table A.8 – Techniques and measures for testing.
-[4] <Document ID> – Software Safety Requirements Specification.
-[5] <Document ID> – Software Design Specification.
-[6] <Project-specific references>
+[1] IEC 61508-3:2010, Clause 7.7 - Software module testing and integration.
+[2] IEC 61508-3:2010, Clause 7.8 - Programmable electronics integration testing.
+[3] IEC 61508-3:2010, Table A.8 - Techniques and measures for testing.
+[4] <Document ID> - Software Safety Requirements Specification.
+[5] <Document ID> - Software Design Specification.
 <<<
 
 [[/SECTION]]

--- a/templates/iec-61508-3/06_sw_test_spec_report.sdoc
+++ b/templates/iec-61508-3/06_sw_test_spec_report.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Software Test Specification and Report
+TITLE: Software test specification and report
 OPTIONS:
   MARKUP: Text
 
@@ -34,7 +34,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -54,7 +54,7 @@ Test Environment: <Hardware platform, OS, toolchain, test framework version>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Test Strategy
+TITLE: Test strategy
 
 [TEXT]
 STATEMENT: >>>
@@ -72,7 +72,7 @@ Coverage target per SIL (IEC 61508-3:2010 Table A.8):
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Unit Tests
+TITLE: Unit tests
 
 [TEST_CASE]
 UID: TC-001
@@ -163,7 +163,7 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Integration Tests
+TITLE: Integration tests
 
 [TEST_CASE]
 UID: TC-100
@@ -226,7 +226,7 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: HW-SW Integration Tests
+TITLE: HW-SW integration tests
 
 [TEST_CASE]
 UID: TC-200
@@ -292,7 +292,7 @@ RELATIONS:
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Test Coverage Summary
+TITLE: Test coverage summary
 
 [TEXT]
 STATEMENT: >>>
@@ -308,7 +308,7 @@ Uncovered items: <None / describe with justification>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Outstanding Issues
+TITLE: Outstanding issues
 
 [ACTION_ITEM]
 UID: NCR-001

--- a/templates/iec-61508-3/07_sw_safety_plan.sdoc
+++ b/templates/iec-61508-3/07_sw_safety_plan.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Software Safety Plan
+TITLE: Software safety plan
 OPTIONS:
   MARKUP: Text
 
@@ -32,7 +32,7 @@ Instructions for use:
 <<<
 
 [[SECTION]]
-TITLE: Document Information
+TITLE: Document information
 
 [TEXT]
 STATEMENT: >>>
@@ -51,7 +51,7 @@ OSP Reference:   <Document ID of Overall Safety Plan>
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Safety Lifecycle
+TITLE: Software safety lifecycle
 
 [REQUIREMENT]
 UID: SSP-010
@@ -102,7 +102,7 @@ VERIFICATION_METHOD: Inspection
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Responsibilities and Competence
+TITLE: Responsibilities and competence
 
 [REQUIREMENT]
 UID: SSP-020
@@ -180,7 +180,7 @@ RATIONALE: IEC 61508-3:2010, Clause 6.2.4 and Table 4.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Development Environment and Tools
+TITLE: Development environment and tools
 
 [REQUIREMENT]
 UID: SSP-030
@@ -261,7 +261,7 @@ RATIONALE: IEC 61508-3:2010, Table A.4.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Configuration Management
+TITLE: Configuration management
 
 [REQUIREMENT]
 UID: SSP-040
@@ -333,7 +333,7 @@ VERIFICATION_METHOD: Inspection
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Problem Reporting and Resolution
+TITLE: Problem reporting and resolution
 
 [REQUIREMENT]
 UID: SSP-050
@@ -365,7 +365,7 @@ RATIONALE: IEC 61508-3:2010, Clause 6.2.1.
 [[/SECTION]]
 
 [[SECTION]]
-TITLE: Software Safety Reviews
+TITLE: Software safety reviews
 
 [REQUIREMENT]
 UID: SSP-060

--- a/templates/iec-61508-3/07_sw_safety_plan.sdoc
+++ b/templates/iec-61508-3/07_sw_safety_plan.sdoc
@@ -1,0 +1,426 @@
+[DOCUMENT]
+TITLE: Software Safety Plan
+OPTIONS:
+  MARKUP: Text
+
+[GRAMMAR]
+IMPORT_FROM_FILE: iec_61508_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+This document is the Software Safety Plan (SSP) for the software element of the
+E/E/PE safety-related system identified below. It is prepared in accordance with
+IEC 61508-3:2010, Clause 6.2 (Software safety management), and serves as the
+primary planning document for all software safety lifecycle activities.
+
+The SSP defines:
+- The software safety lifecycle and its phases.
+- Responsibilities and competence requirements.
+- Planning for software development, verification, and validation.
+- Configuration management and documentation control.
+- Tool qualification strategy.
+- Independence requirements.
+
+SIL_1 through SIL_4 fields classify plan requirements as HR/R/NR/--
+per IEC 61508-3:2010.
+
+Instructions for use:
+- UIDs follow convention: SSP-xxx.
+- Adjust the tool list, language, and process descriptions to match
+  the actual project environment.
+- Delete this instruction block before formal release.
+<<<
+
+[[SECTION]]
+TITLE: Document Information
+
+[TEXT]
+STATEMENT: >>>
+Project:         <Project name>
+Software Item:   <Software item / component name>
+Document ID:     <DOC-ID>
+Revision:        <Rev. A>
+Date:            <YYYY-MM-DD>
+Author:          <Name, Role>
+Approved by:     <Name, Role>
+Classification:  <Confidential / Restricted / Public>
+Target SIL:      <SIL 1 / SIL 2 / SIL 3 / SIL 4>
+OSP Reference:   <Document ID of Overall Safety Plan>
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Safety Lifecycle
+
+[REQUIREMENT]
+UID: SSP-010
+STATUS: Draft
+TITLE: Software safety lifecycle definition
+STATEMENT: >>>
+The software shall be developed in accordance with the software safety lifecycle
+defined in IEC 61508-3:2010, Figure 2, comprising the following phases:
+1. Software Safety Requirements Specification
+2. Software Architecture Design
+3. Software Detailed Design and Implementation
+4. Software Module Testing
+5. Software Integration Testing
+6. Software / Hardware Integration Testing
+7. Software Validation
+
+Each phase shall have defined entry criteria, activities, deliverables,
+and exit criteria as specified in this plan.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.1.
+
+[REQUIREMENT]
+UID: SSP-011
+STATUS: Draft
+TITLE: Software safety lifecycle deliverables
+STATEMENT: >>>
+The following documents shall be produced as software safety lifecycle
+deliverables:
+- Software Safety Plan (this document)
+- Software Safety Requirements Specification (SSRS)
+- Software Design Specification (SDS)
+- Software Test Specification and Report (STS/STR)
+- Software Validation Report
+- Configuration Management Records
+- Problem Reporting and Resolution Records
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Responsibilities and Competence
+
+[REQUIREMENT]
+UID: SSP-020
+STATUS: Draft
+TITLE: Software safety team roles
+STATEMENT: >>>
+The following roles are defined for software safety activities:
+
+Software Safety Manager:  <Name>
+  Responsibilities: Overall software safety management; approval of
+  safety lifecycle deliverables; liaison with functional safety assessor.
+
+Software Architect:       <Name>
+  Responsibilities: Software architecture design; architecture verification.
+
+Software Developer(s):   <Name(s)>
+  Responsibilities: Detailed design and implementation; unit testing.
+
+Software Verifier:        <Name>
+  Responsibilities: Independent verification of design and code;
+  static analysis; test coverage analysis.
+
+Functional Safety Assessor: <Name / Organisation>
+  Responsibilities: Independent assessment of software safety activities
+  and deliverables per IEC 61508-3:2010, Clause 8.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.1.
+
+[REQUIREMENT]
+UID: SSP-021
+STATUS: Draft
+TITLE: Competence requirements
+STATEMENT: >>>
+Persons assigned to software safety activities shall demonstrate competence
+appropriate to their role and to the target SIL, as evidenced by:
+- Relevant education and/or professional qualifications.
+- Experience in safety-related software development.
+- Knowledge of IEC 61508-3 and applicable coding standards.
+- Training records for project-specific tools and methods.
+
+Competence records shall be maintained for all team members.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.1 and Annex D.
+
+[REQUIREMENT]
+UID: SSP-022
+STATUS: Draft
+TITLE: Independence of verification
+STATEMENT: >>>
+Software verification activities shall be performed by persons independent
+from the software development activities, at the following level of independence:
+- SIL 1/2: Independence within the project team (different person).
+- SIL 3:   Independence within the organisation (different department or group).
+- SIL 4:   Full organisational independence (separate company or certified body).
+
+The designated independent verifier for this project is: <Name / Organisation>.
+<<<
+SIL_1: R
+SIL_2: R
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.4 and Table 4.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Development Environment and Tools
+
+[REQUIREMENT]
+UID: SSP-030
+STATUS: Draft
+TITLE: Development toolchain definition
+STATEMENT: >>>
+The following tools are used in the software development lifecycle.
+Each tool is classified per IEC 61508-3:2010, Clause 7.4.4 (T1/T2/T3):
+
+T1: No tool output used in executable code, tool errors do not affect safety.
+T2: Tool validates requirements or design; errors could cause undetected failure.
+T3: Tool output included in safety-related executable; errors could cause failure.
+
+Tool                    | Version  | Class | Qualification required
+------------------------|----------|-------|------------------------
+<Compiler>              | <x.y.z>  | T3    | Yes – per IEC 61508-3 §7.4.4
+<Static analysis tool>  | <x.y.z>  | T2    | Yes – per IEC 61508-3 §7.4.4
+<Test framework>        | <x.y.z>  | T2    | Yes
+<Coverage tool>         | <x.y.z>  | T2    | Yes
+<Requirements tool>     | <x.y.z>  | T2    | Yes
+<Version control>       | <x.y.z>  | T1    | No
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 7.4.4.
+
+[REQUIREMENT]
+UID: SSP-031
+STATUS: Draft
+TITLE: Tool qualification strategy
+STATEMENT: >>>
+T3 and T2 tools shall be qualified before use in safety-related development.
+Qualification shall demonstrate that the tool produces correct outputs for
+inputs within the expected usage domain, using one or more of:
+a) Vendor certificate of tool qualification (e.g. TÜV-certified compiler).
+b) Tool validation tests executed against known inputs with verified outputs.
+c) Diverse independent tool used to cross-check outputs.
+
+Tool qualification records shall be maintained and referenced from the
+configuration management system.
+<<<
+SIL_1: R
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 7.4.4.
+
+[REQUIREMENT]
+UID: SSP-032
+STATUS: Draft
+TITLE: Programming language and coding standard
+STATEMENT: >>>
+The software shall be implemented in: <Programming language, version>
+
+The applicable coding standard is: <e.g. MISRA C:2012>
+
+The following language features are explicitly prohibited:
+- <dynamic memory allocation after startup>
+- <unbounded recursion>
+- <use of setjmp / longjmp>
+- <implementation-defined behaviour>
+- <other project-specific prohibitions>
+
+Compliance with the coding standard shall be enforced using
+<static analysis tool> and verified during code review.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.4.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Configuration Management
+
+[REQUIREMENT]
+UID: SSP-040
+STATUS: Draft
+TITLE: Configuration management system
+STATEMENT: >>>
+All software configuration items (SCIs) shall be managed using
+<version control system, e.g. Git>. The following items shall be
+placed under configuration management:
+- Software source code and header files
+- Build scripts and makefiles
+- Software safety lifecycle documents
+- Test cases and test scripts
+- Tool qualification records
+- Problem reports and resolution records
+
+Repository location: <URL or path>
+Branching strategy: <describe branching model, e.g. main/develop/feature>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.1.
+
+[REQUIREMENT]
+UID: SSP-041
+STATUS: Draft
+TITLE: Change control process
+STATEMENT: >>>
+All changes to software configuration items after the initial baseline
+shall be subject to a formal change control process:
+1. Change request raised and documented.
+2. Impact analysis performed, including safety impact assessment.
+3. Change approved by Software Safety Manager.
+4. Change implemented and verified.
+5. New baseline created and documented.
+
+Changes with potential safety impact shall be reviewed by the
+independent verifier before the new baseline is approved.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[REQUIREMENT]
+UID: SSP-042
+STATUS: Draft
+TITLE: Baseline identification
+STATEMENT: >>>
+A software baseline shall be established at the completion of each
+safety lifecycle phase. Each baseline shall be identified by:
+- Unique baseline identifier (e.g. SW-BL-001)
+- Date and version of each configuration item included
+- Reference to the phase exit review record
+
+The safety validation baseline shall be the basis for the released
+software product.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Problem Reporting and Resolution
+
+[REQUIREMENT]
+UID: SSP-050
+STATUS: Draft
+TITLE: Problem reporting process
+STATEMENT: >>>
+All defects, failures, and non-conformances discovered during any
+software safety lifecycle phase shall be recorded in a Problem Report (PR).
+Each PR shall include:
+- Unique identifier
+- Date and phase of discovery
+- Description of the problem
+- Severity classification (Safety-Critical / Major / Minor)
+- Status (Open / Under Investigation / Resolved / Closed)
+- Resolution description and verification
+
+Problem reports shall be tracked to closure before software safety
+validation is declared complete.
+
+PR tracking system: <tool / document reference>
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 6.2.1.
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Software Safety Reviews
+
+[REQUIREMENT]
+UID: SSP-060
+STATUS: Draft
+TITLE: Phase exit reviews
+STATEMENT: >>>
+A formal phase exit review shall be conducted at the completion of each
+software safety lifecycle phase. The review shall verify that:
+- All phase deliverables have been produced and are consistent.
+- All entry criteria for the next phase are satisfied.
+- All open problem reports are at an acceptable status.
+- Traceability between phases is maintained.
+
+Review records shall include: attendees, date, findings, action items,
+and pass/fail decision.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Clause 7.5.
+
+[REQUIREMENT]
+UID: SSP-061
+STATUS: Draft
+TITLE: Design and code reviews
+STATEMENT: >>>
+Formal reviews (walk-throughs or inspections) shall be conducted for:
+- Software architecture design (before detailed design commences)
+- Detailed design for safety-critical modules
+- Source code for safety-critical modules
+
+Review participants shall include at least one person independent from
+the author. Review findings shall be recorded and tracked to closure.
+<<<
+SIL_1: HR
+SIL_2: HR
+SIL_3: HR
+SIL_4: HR
+VERIFICATION_METHOD: Inspection
+RATIONALE: IEC 61508-3:2010, Table A.5 – Walk-through / inspection (HR SIL 1-4).
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: References
+
+[TEXT]
+STATEMENT: >>>
+[1] IEC 61508-3:2010, Clause 6.2 – Software safety management.
+[2] IEC 61508-3:2010, Clause 7.4.4 – Software tools.
+[3] IEC 61508-3:2010, Annex D – Competence of persons.
+[4] <Document ID> – Overall Safety Plan.
+[5] <Project-specific references>
+<<<
+
+[[/SECTION]]

--- a/templates/iec-61508-3/README.md
+++ b/templates/iec-61508-3/README.md
@@ -19,7 +19,7 @@ IEC 61508-3:2010 and the overall safety management activities of IEC 61508-1:201
 | `06_sw_test_spec_report.sdoc` | Software Test Specification and Report (STS/STR) | IEC 61508-3:2010, §7.7–7.8 |
 | `07_sw_safety_plan.sdoc` | Software Safety Plan (SSP / SQAP) | IEC 61508-3:2010, §6.2 |
 
-The shared grammar is in `grammar/iec_61508_grammar.sgra` and is imported by all
+The shared grammar is in `iec_61508_grammar.sgra` and is imported by all
 document templates.
 
 ## Key Features
@@ -108,7 +108,7 @@ estimation methods (e.g. LOPA, numerical risk targets per IEC 61508-1 Annex C).
 
 ## Customisation
 
-The grammar file `grammar/iec_61508_grammar.sgra` can be extended to add
+The grammar file `iec_61508_grammar.sgra` can be extended to add
 project-specific fields. For example, to add an `OWNER` field or a custom
 `ASIL`-equivalent field, edit the grammar and add the field to the relevant
 element definition.

--- a/templates/iec-61508-3/README.md
+++ b/templates/iec-61508-3/README.md
@@ -1,0 +1,131 @@
+# IEC 61508 Safety Lifecycle Templates
+
+This directory contains StrictDoc templates for the **IEC 61508:2010** functional safety
+standard (*Functional safety of electrical/electronic/programmable electronic
+safety-related systems*).
+
+The templates cover the software-focused safety lifecycle defined in
+IEC 61508-3:2010 and the overall safety management activities of IEC 61508-1:2010.
+
+## Document Set
+
+| File | Document | Standard reference |
+|------|----------|--------------------|
+| `01_overall_safety_plan.sdoc` | Overall Safety Plan (OSP) | IEC 61508-1:2010, §6.2 |
+| `02_hazard_risk_analysis.sdoc` | Hazard and Risk Analysis (HARA) | IEC 61508-1:2010, §7.4, Annex D |
+| `03_safety_requirements_spec.sdoc` | Safety Requirements Specification (SRS) | IEC 61508-1:2010, §7.6 |
+| `04_sw_safety_requirements_spec.sdoc` | Software Safety Requirements Specification (SSRS) | IEC 61508-3:2010, §7.2 |
+| `05_sw_design_spec.sdoc` | Software Design Specification (SDS) | IEC 61508-3:2010, §7.3–7.4 |
+| `06_sw_test_spec_report.sdoc` | Software Test Specification and Report (STS/STR) | IEC 61508-3:2010, §7.7–7.8 |
+| `07_sw_safety_plan.sdoc` | Software Safety Plan (SSP / SQAP) | IEC 61508-3:2010, §6.2 |
+
+The shared grammar is in `grammar/iec_61508_grammar.sgra` and is imported by all
+document templates.
+
+## Key Features
+
+### SIL Applicability Fields
+
+Every `REQUIREMENT` node carries four fields that encode the SIL applicability
+of the corresponding requirement or technique, based on IEC 61508-3:2010
+Tables A.1–A.10:
+
+| Field | Meaning |
+|-------|---------|
+| `SIL_1` | Applicability at SIL 1 |
+| `SIL_2` | Applicability at SIL 2 |
+| `SIL_3` | Applicability at SIL 3 |
+| `SIL_4` | Applicability at SIL 4 |
+
+Values: `HR` (Highly Recommended), `R` (Recommended), `NR` (Not Recommended),
+`--` (Not applicable).
+
+This allows StrictDoc's query engine to filter requirements by SIL level.
+For example, to list all requirements that are Highly Recommended at SIL 3:
+
+```
+strictdoc export . --filter "SIL_3 == 'HR'"
+```
+
+Or in the web UI: use the **Search** panel with the expression above.
+
+### Traceability
+
+The templates are designed with the full traceability chain in mind:
+
+```
+HARA (HAZ-xxx)
+  └─▶ SRS (SRS-xxx)
+        └─▶ SSRS (SSRS-xxx)
+              ├─▶ SDS (SDS-xxx)
+              └─▶ STS (STS-xxx)
+```
+
+Each `REQUIREMENT` node uses `RELATIONS: TYPE: Parent` to establish
+upward traceability. StrictDoc generates the bidirectional traceability
+matrix automatically.
+
+### Risk Graph (HARA)
+
+The `HAZARD` node models the IEC 61508-1:2010 Annex D Risk Graph parameters:
+
+- `RISK_GRAPH_C` – Consequence (C1–C4)
+- `RISK_GRAPH_F` – Frequency/exposure (F1–F2)
+- `RISK_GRAPH_P` – Possibility of avoidance (P1–P2)
+- `RISK_GRAPH_W` – Probability of unwanted occurrence (W1–W3)
+- `SIL_REQUIRED` – SIL determined from the Risk Graph
+
+The `RISK_METHOD_ALT` field is available for documenting alternative risk
+estimation methods (e.g. LOPA, numerical risk targets per IEC 61508-1 Annex C).
+
+## Getting Started
+
+1. Install StrictDoc:
+   ```
+   pip install strictdoc
+   ```
+
+2. Copy the `iec-61508/` directory to your project:
+   ```
+   cp -r templates/iec-61508/ my-project/docs/
+   ```
+
+3. Edit `strictdoc.toml` to set the project title and input paths.
+
+4. Start the web server to edit documents interactively:
+   ```
+   strictdoc server .
+   ```
+
+5. Replace all placeholder text (`<...>`) with project-specific content.
+
+6. Assign UIDs following your project's numbering convention.
+
+7. Export to HTML or PDF:
+   ```
+   strictdoc export .
+   ```
+
+## Customisation
+
+The grammar file `grammar/iec_61508_grammar.sgra` can be extended to add
+project-specific fields. For example, to add an `OWNER` field or a custom
+`ASIL`-equivalent field, edit the grammar and add the field to the relevant
+element definition.
+
+## Disclaimer
+
+These templates are intended as a starting point to assist engineers in
+structuring IEC 61508 safety lifecycle documentation using StrictDoc.
+They do **not** constitute legal or certification advice and do **not**
+guarantee compliance with IEC 61508 or any regulatory requirement.
+The templates must be adapted to the specific system, context, and applicable
+SIL by a competent functional safety engineer. Always verify the current version
+of IEC 61508 and consult your Functional Safety Assessor.
+
+## References
+
+- IEC 61508-1:2010 – General requirements
+- IEC 61508-2:2010 – Requirements for E/E/PE safety-related systems
+- IEC 61508-3:2010 – Software requirements
+- [StrictDoc documentation](https://strictdoc.readthedocs.io)

--- a/templates/iec-61508-3/iec_61508_grammar.sgra
+++ b/templates/iec-61508-3/iec_61508_grammar.sgra
@@ -1,0 +1,133 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+- TAG: TEXT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: SingleChoice(Draft, Active, Obsolete, Rejected)
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: SAFETY_FUNCTION
+    TYPE: String
+    REQUIRED: False
+  - TITLE: SIL_1
+    TYPE: SingleChoice(HR, R, NR, --)
+    REQUIRED: False
+  - TITLE: SIL_2
+    TYPE: SingleChoice(HR, R, NR, --)
+    REQUIRED: False
+  - TITLE: SIL_3
+    TYPE: SingleChoice(HR, R, NR, --)
+    REQUIRED: False
+  - TITLE: SIL_4
+    TYPE: SingleChoice(HR, R, NR, --)
+    REQUIRED: False
+  - TITLE: VERIFICATION_METHOD
+    TYPE: MultipleChoice(Analysis, Testing, Inspection, Simulation, FormalProof)
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+- TAG: HAZARD
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: SingleChoice(Draft, Active, Mitigated, Residual, Closed)
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: HAZARD_DESCRIPTION
+    TYPE: String
+    REQUIRED: False
+  - TITLE: CAUSE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: CONSEQUENCE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RISK_GRAPH_C
+    TYPE: SingleChoice(C1, C2, C3, C4)
+    REQUIRED: False
+  - TITLE: RISK_GRAPH_F
+    TYPE: SingleChoice(F1, F2)
+    REQUIRED: False
+  - TITLE: RISK_GRAPH_P
+    TYPE: SingleChoice(P1, P2)
+    REQUIRED: False
+  - TITLE: RISK_GRAPH_W
+    TYPE: SingleChoice(W1, W2, W3)
+    REQUIRED: False
+  - TITLE: SIL_REQUIRED
+    TYPE: SingleChoice(--, SIL1, SIL2, SIL3, SIL4, No-SIL-Required)
+    REQUIRED: False
+  - TITLE: RISK_METHOD_ALT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: MITIGATION
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+- TAG: ACTION_ITEM
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: SingleChoice(Open, Closed, Deferred)
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: OWNER
+    TYPE: String
+    REQUIRED: False
+  - TITLE: DUE_DATE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent

--- a/templates/iec-61508-3/iec_61508_grammar.sgra
+++ b/templates/iec-61508-3/iec_61508_grammar.sgra
@@ -106,6 +106,47 @@ ELEMENTS:
     REQUIRED: False
   RELATIONS:
   - TYPE: Parent
+- TAG: TEST_CASE
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: SingleChoice(Draft, Active, Obsolete)
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TEST_TYPE
+    TYPE: SingleChoice(Unit, Integration, HW-SW-Integration, Validation)
+    REQUIRED: False
+  - TITLE: PRECONDITIONS
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STEPS
+    TYPE: String
+    REQUIRED: False
+  - TITLE: EXPECTED_RESULT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: ACTUAL_RESULT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: VERDICT
+    TYPE: SingleChoice(PASS, FAIL, NOT_RUN, BLOCKED)
+    REQUIRED: False
+  - TITLE: DATE_EXECUTED
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TESTER
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+    ROLE: Verifies
 - TAG: ACTION_ITEM
   FIELDS:
   - TITLE: UID


### PR DESCRIPTION
## Summary

This PR adds a set of StrictDoc templates covering the **IEC 61508:2010**
functional safety lifecycle, with a focus on the software requirements of
IEC 61508-3:2010.

## Documents included

| File | Document | Standard reference |
|------|----------|--------------------|
| `01_overall_safety_plan.sdoc` | Overall Safety Plan | IEC 61508-1:2010, §6.2 |
| `02_hazard_risk_analysis.sdoc` | Hazard and Risk Analysis | IEC 61508-1:2010, §7.4, Annex D |
| `03_safety_requirements_spec.sdoc` | Safety Requirements Specification | IEC 61508-1:2010, §7.6 |
| `04_sw_safety_requirements_spec.sdoc` | Software Safety Requirements Specification | IEC 61508-3:2010, §7.2 |
| `05_sw_design_spec.sdoc` | Software Design Specification | IEC 61508-3:2010, §7.3–7.4 |
| `06_sw_test_spec_report.sdoc` | Software Test Specification and Report | IEC 61508-3:2010, §7.7–7.8 |
| `07_sw_safety_plan.sdoc` | Software Safety Plan / SQAP | IEC 61508-3:2010, §6.2 |

## Key design decisions

**SIL applicability fields:** Every `REQUIREMENT` node carries four fields
(`SIL_1`, `SIL_2`, `SIL_3`, `SIL_4`) with values `HR` / `R` / `NR` / `--`,
reflecting the classification from IEC 61508-3:2010 Tables A.1–A.10.
This enables filtering requirements by SIL level using StrictDoc's query engine.

**Dedicated `TEST_CASE` node:** The shared grammar defines a `TEST_CASE` element
with fields `TEST_TYPE`, `PRECONDITIONS`, `STEPS`, `EXPECTED_RESULT`,
`ACTUAL_RESULT`, `VERDICT`, `DATE_EXECUTED`, and `TESTER`. Test cases link to
SSRS requirements using `ROLE: Verifies`, producing a verification traceability
column distinct from the hierarchical parent-child relationships.

**Risk Graph support:** The `HAZARD` node models the IEC 61508-1:2010 Annex D
Risk Graph parameters (C, F, P, W) with a `SIL_REQUIRED` result field and a
`RISK_METHOD_ALT` field for alternative methods (LOPA, numerical targets).

**Shared grammar:** All documents import a single `iec_61508_grammar.sgra` file,
keeping element definitions consistent across the document set.

## Traceability chain

```
HAZARD (HAZ-xxx)
  └─▶ REQUIREMENT/SRS (SRS-xxx)
        └─▶ REQUIREMENT/SSRS (SSRS-xxx)
              ├─▶ REQUIREMENT/SDS (SDS-xxx)
              └─▶ TEST_CASE (TC-xxx)  [ROLE: Verifies]
```

## Validation

All templates have been validated with `strictdoc export` on StrictDoc 0.21.1
with zero errors. A self-contained example project (industrial heater controller,
SIL 2) demonstrating the full traceability chain is available and can be provided
separately as a usage example if useful.

## Notes

- Syntax uses `[[SECTION]]` (SDocCompositeNode) per StrictDoc 0.21.1.
- `IMPORT_FROM_FILE` references a grammar file in the same directory
  (path separators not supported by the validator).
- `OPTIONS: MARKUP: Text` is set on all documents to avoid RST parser
  interference with plain-text content in STATEMENT fields.



