### PR TITLE
Fix field order: move STATEMENT before SAFETY_FUNCTION to match stric…

### DIFF
--- a/templates/iec-61508-3/03_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/03_safety_requirements_spec.sdoc
@@ -81,8 +81,8 @@ For each safety function specify:
 UID: SRS-010
 STATUS: Draft
 TITLE: <Safety Function 1 name>
-SAFETY_FUNCTION: SF-1
 STATEMENT: >>>
+SAFETY_FUNCTION: SF-1
 The <system name> shall perform <describe the safety function: action> upon
 detection of <describe the initiating condition / process demand> within
 <response time> milliseconds, bringing the EUC to the safe state defined as
@@ -110,8 +110,8 @@ RELATIONS:
 UID: SRS-011
 STATUS: Draft
 TITLE: <Safety Function 2 name>
-SAFETY_FUNCTION: SF-2
 STATEMENT: >>>
+SAFETY_FUNCTION: SF-2
 The <system name> shall <describe safety function 2>.
 
 Required SIL: <SIL x>

--- a/templates/iec-61508-3/03_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/03_safety_requirements_spec.sdoc
@@ -82,7 +82,6 @@ UID: SRS-010
 STATUS: Draft
 TITLE: <Safety Function 1 name>
 STATEMENT: >>>
-SAFETY_FUNCTION: SF-1
 The <system name> shall perform <describe the safety function: action> upon
 detection of <describe the initiating condition / process demand> within
 <response time> milliseconds, bringing the EUC to the safe state defined as
@@ -93,6 +92,7 @@ Target failure measure: PFH < <value> h⁻¹ (continuous mode) /
                          PFD_avg < <value> (demand mode)
 Proof test interval: <value> hours (if applicable)
 <<<
+SAFETY_FUNCTION: SF-1
 SIL_1: HR
 SIL_2: HR
 SIL_3: HR
@@ -111,12 +111,12 @@ UID: SRS-011
 STATUS: Draft
 TITLE: <Safety Function 2 name>
 STATEMENT: >>>
-SAFETY_FUNCTION: SF-2
 The <system name> shall <describe safety function 2>.
 
 Required SIL: <SIL x>
 Target failure measure: PFH < <value> h⁻¹
 <<<
+SAFETY_FUNCTION: SF-2
 SIL_1: HR
 SIL_2: HR
 SIL_3: HR

--- a/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
@@ -80,7 +80,6 @@ UID: SSRS-010
 STATUS: Draft
 TITLE: <Software safety function 1>
 STATEMENT: >>>
-SAFETY_FUNCTION: SF-1
 The software shall <describe the software behaviour required to realise
 the safety function, including: inputs monitored, logic applied, outputs
 commanded, timing constraints>.
@@ -90,6 +89,7 @@ Output signals: <list>
 Response time: < <value> ms from input detection to output activation.
 Safe output state: <define>
 <<<
+SAFETY_FUNCTION: SF-1
 SIL_1: HR
 SIL_2: HR
 SIL_3: HR
@@ -107,9 +107,9 @@ UID: SSRS-011
 STATUS: Draft
 TITLE: <Software safety function 2>
 STATEMENT: >>>
-SAFETY_FUNCTION: SF-2
 The software shall <describe the software behaviour for safety function 2>.
 <<<
+SAFETY_FUNCTION: SF-2
 SIL_1: HR
 SIL_2: HR
 SIL_3: HR

--- a/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
+++ b/templates/iec-61508-3/04_sw_safety_requirements_spec.sdoc
@@ -79,8 +79,8 @@ Each requirement shall be unambiguous, verifiable, complete, and consistent.
 UID: SSRS-010
 STATUS: Draft
 TITLE: <Software safety function 1>
-SAFETY_FUNCTION: SF-1
 STATEMENT: >>>
+SAFETY_FUNCTION: SF-1
 The software shall <describe the software behaviour required to realise
 the safety function, including: inputs monitored, logic applied, outputs
 commanded, timing constraints>.
@@ -106,8 +106,8 @@ RELATIONS:
 UID: SSRS-011
 STATUS: Draft
 TITLE: <Software safety function 2>
-SAFETY_FUNCTION: SF-2
 STATEMENT: >>>
+SAFETY_FUNCTION: SF-2
 The software shall <describe the software behaviour for safety function 2>.
 <<<
 SIL_1: HR


### PR DESCRIPTION
## Summary
Fix strictdoc parsing error by reordering fields in the IEC 61508-3 template.
## Problem
strictdoc v1 rejects requirement blocks where `SAFETY_FUNCTION` appears before `STATEMENT`, because the grammar requires the order: `UID, STATUS, TITLE, STATEMENT, SAFETY_FUNCTION, ...`.
## Changes
Swapped `SAFETY_FUNCTION` and `STATEMENT` fields in 4 requirements across 2 files:
| File | Requirements |
|---|---|
| `03_safety_requirements_spec.sdoc` | SRS-010, SRS-011 |
| `04_sw_safety_requirements_spec.sdoc` | SSRS-010, SSRS-011 |
No content was modified, only the field order.